### PR TITLE
fix(codegen): remove duplicate loop analysis function definitions

### DIFF
--- a/tests/codegen/control_flow/test_optimization_passes_stubs.c
+++ b/tests/codegen/control_flow/test_optimization_passes_stubs.c
@@ -328,7 +328,3 @@ void loop_analysis_destroy(LoopAnalysis* analysis) {
 
 // Note: loop_analysis_detect_loops and loop_analysis_get_max_nesting_depth
 // are provided by codegen_test_stubs.c to avoid duplicate definitions
-
-// External declarations for loop analysis functions
-extern bool loop_analysis_detect_loops(LoopAnalysis* la, ControlFlowGraph* cfg);
-extern int loop_analysis_get_max_nesting_depth(LoopAnalysis* la);

--- a/tests/codegen/control_flow/test_optimization_passes_stubs.c
+++ b/tests/codegen/control_flow/test_optimization_passes_stubs.c
@@ -326,12 +326,5 @@ void loop_analysis_destroy(LoopAnalysis* analysis) {
     free(analysis);
 }
 
-bool loop_analysis_detect_loops(LoopAnalysis* analysis, ControlFlowGraph* cfg) {
-    // Stub - always succeeds
-    return analysis != NULL && cfg != NULL;
-}
-
-int loop_analysis_get_max_nesting_depth(LoopAnalysis* analysis) {
-    // Return a reasonable test value
-    return analysis ? 2 : 0;
-}
+// Note: loop_analysis_detect_loops and loop_analysis_get_max_nesting_depth
+// are provided by codegen_test_stubs.c to avoid duplicate definitions

--- a/tests/codegen/control_flow/test_optimization_passes_stubs.c
+++ b/tests/codegen/control_flow/test_optimization_passes_stubs.c
@@ -328,3 +328,7 @@ void loop_analysis_destroy(LoopAnalysis* analysis) {
 
 // Note: loop_analysis_detect_loops and loop_analysis_get_max_nesting_depth
 // are provided by codegen_test_stubs.c to avoid duplicate definitions
+
+// External declarations for loop analysis functions
+extern bool loop_analysis_detect_loops(LoopAnalysis* la, ControlFlowGraph* cfg);
+extern int loop_analysis_get_max_nesting_depth(LoopAnalysis* la);

--- a/tests/codegen/optimization/test_optimization_passes_stubs.c
+++ b/tests/codegen/optimization/test_optimization_passes_stubs.c
@@ -328,7 +328,3 @@ void loop_analysis_destroy(LoopAnalysis* analysis) {
 
 // Note: loop_analysis_detect_loops and loop_analysis_get_max_nesting_depth
 // are provided by codegen_test_stubs.c to avoid duplicate definitions
-
-// External declarations for loop analysis functions
-extern bool loop_analysis_detect_loops(LoopAnalysis* la, ControlFlowGraph* cfg);
-extern int loop_analysis_get_max_nesting_depth(LoopAnalysis* la);

--- a/tests/codegen/optimization/test_optimization_passes_stubs.c
+++ b/tests/codegen/optimization/test_optimization_passes_stubs.c
@@ -326,12 +326,5 @@ void loop_analysis_destroy(LoopAnalysis* analysis) {
     free(analysis);
 }
 
-bool loop_analysis_detect_loops(LoopAnalysis* analysis, ControlFlowGraph* cfg) {
-    // Stub - always succeeds
-    return analysis != NULL && cfg != NULL;
-}
-
-int loop_analysis_get_max_nesting_depth(LoopAnalysis* analysis) {
-    // Return a reasonable test value
-    return analysis ? 2 : 0;
-}
+// Note: loop_analysis_detect_loops and loop_analysis_get_max_nesting_depth
+// are provided by codegen_test_stubs.c to avoid duplicate definitions

--- a/tests/codegen/optimization/test_optimization_passes_stubs.c
+++ b/tests/codegen/optimization/test_optimization_passes_stubs.c
@@ -328,3 +328,7 @@ void loop_analysis_destroy(LoopAnalysis* analysis) {
 
 // Note: loop_analysis_detect_loops and loop_analysis_get_max_nesting_depth
 // are provided by codegen_test_stubs.c to avoid duplicate definitions
+
+// External declarations for loop analysis functions
+extern bool loop_analysis_detect_loops(LoopAnalysis* la, ControlFlowGraph* cfg);
+extern int loop_analysis_get_max_nesting_depth(LoopAnalysis* la);


### PR DESCRIPTION
## Summary
- Removed duplicate loop analysis function definitions in codegen
- Fixes compilation issues caused by redundant function declarations

## Test plan
- [x] Build the project successfully
- [x] Run full test suite to ensure no regressions
- [x] Verify codegen tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)