### PR TITLE
Fix deep cloning for AST nodes with ASTNodeList fields

### DIFF
--- a/src/parser/ast_node_creation.c
+++ b/src/parser/ast_node_creation.c
@@ -182,9 +182,9 @@ ASTNode *ast_clone_node(ASTNode *node) {
             if (node->data.struct_literal.struct_name) {
                 clone->data.struct_literal.struct_name = strdup(node->data.struct_literal.struct_name);
             }
-            // TODO: Implement deep cloning of type_args and field_inits when needed
-            clone->data.struct_literal.type_args = node->data.struct_literal.type_args;
-            clone->data.struct_literal.field_inits = node->data.struct_literal.field_inits;
+            // Deep clone type_args and field_inits
+            clone->data.struct_literal.type_args = ast_node_list_clone_deep(node->data.struct_literal.type_args);
+            clone->data.struct_literal.field_inits = ast_node_list_clone_deep(node->data.struct_literal.field_inits);
             break;
             
         case AST_IDENTIFIER:
@@ -209,10 +209,10 @@ ASTNode *ast_clone_node(ASTNode *node) {
                 clone->data.enum_decl.name = strdup(node->data.enum_decl.name);
             }
             clone->data.enum_decl.visibility = node->data.enum_decl.visibility;
-            // TODO: Implement deep cloning of variants and type_params when needed
-            clone->data.enum_decl.variants = node->data.enum_decl.variants;
-            clone->data.enum_decl.type_params = node->data.enum_decl.type_params;
-            clone->data.enum_decl.annotations = node->data.enum_decl.annotations;
+            // Deep clone variants, type_params, and annotations
+            clone->data.enum_decl.variants = ast_node_list_clone_deep(node->data.enum_decl.variants);
+            clone->data.enum_decl.type_params = ast_node_list_clone_deep(node->data.enum_decl.type_params);
+            clone->data.enum_decl.annotations = ast_node_list_clone_deep(node->data.enum_decl.annotations);
             break;
             
         case AST_ENUM_VARIANT_DECL:
@@ -222,6 +222,384 @@ ASTNode *ast_clone_node(ASTNode *node) {
             clone->data.enum_variant_decl.visibility = node->data.enum_variant_decl.visibility;
             clone->data.enum_variant_decl.associated_type = ast_clone_node(node->data.enum_variant_decl.associated_type);
             clone->data.enum_variant_decl.value = ast_clone_node(node->data.enum_variant_decl.value);
+            break;
+            
+        case AST_PROGRAM:
+            clone->data.program.package_decl = ast_clone_node(node->data.program.package_decl);
+            clone->data.program.imports = ast_node_list_clone_deep(node->data.program.imports);
+            clone->data.program.declarations = ast_node_list_clone_deep(node->data.program.declarations);
+            break;
+            
+        case AST_FUNCTION_DECL:
+            if (node->data.function_decl.name) {
+                clone->data.function_decl.name = strdup(node->data.function_decl.name);
+            }
+            clone->data.function_decl.params = ast_node_list_clone_deep(node->data.function_decl.params);
+            clone->data.function_decl.return_type = ast_clone_node(node->data.function_decl.return_type);
+            clone->data.function_decl.body = ast_clone_node(node->data.function_decl.body);
+            clone->data.function_decl.visibility = node->data.function_decl.visibility;
+            clone->data.function_decl.annotations = ast_node_list_clone_deep(node->data.function_decl.annotations);
+            break;
+            
+        case AST_STRUCT_DECL:
+            if (node->data.struct_decl.name) {
+                clone->data.struct_decl.name = strdup(node->data.struct_decl.name);
+            }
+            clone->data.struct_decl.fields = ast_node_list_clone_deep(node->data.struct_decl.fields);
+            clone->data.struct_decl.type_params = ast_node_list_clone_deep(node->data.struct_decl.type_params);
+            clone->data.struct_decl.visibility = node->data.struct_decl.visibility;
+            clone->data.struct_decl.annotations = ast_node_list_clone_deep(node->data.struct_decl.annotations);
+            break;
+            
+        case AST_CALL_EXPR:
+            clone->data.call_expr.function = ast_clone_node(node->data.call_expr.function);
+            clone->data.call_expr.args = ast_node_list_clone_deep(node->data.call_expr.args);
+            break;
+            
+        case AST_ARRAY_LITERAL:
+            clone->data.array_literal.elements = ast_node_list_clone_deep(node->data.array_literal.elements);
+            break;
+            
+        case AST_BLOCK:
+            clone->data.block.statements = ast_node_list_clone_deep(node->data.block.statements);
+            break;
+            
+        case AST_ASSOCIATED_FUNC_CALL:
+            if (node->data.associated_func_call.struct_name) {
+                clone->data.associated_func_call.struct_name = strdup(node->data.associated_func_call.struct_name);
+            }
+            if (node->data.associated_func_call.function_name) {
+                clone->data.associated_func_call.function_name = strdup(node->data.associated_func_call.function_name);
+            }
+            clone->data.associated_func_call.type_args = ast_node_list_clone_deep(node->data.associated_func_call.type_args);
+            clone->data.associated_func_call.args = ast_node_list_clone_deep(node->data.associated_func_call.args);
+            break;
+            
+        case AST_MATCH_STMT:
+            clone->data.match_stmt.expression = ast_clone_node(node->data.match_stmt.expression);
+            clone->data.match_stmt.arms = ast_node_list_clone_deep(node->data.match_stmt.arms);
+            break;
+            
+        case AST_POSTFIX_EXPR:
+            clone->data.postfix_expr.base = ast_clone_node(node->data.postfix_expr.base);
+            clone->data.postfix_expr.suffixes = ast_node_list_clone_deep(node->data.postfix_expr.suffixes);
+            break;
+            
+        case AST_TUPLE_LITERAL:
+            clone->data.tuple_literal.elements = ast_node_list_clone_deep(node->data.tuple_literal.elements);
+            break;
+            
+        case AST_TUPLE_TYPE:
+            clone->data.tuple_type.element_types = ast_node_list_clone_deep(node->data.tuple_type.element_types);
+            break;
+            
+        case AST_IMPL_BLOCK:
+            if (node->data.impl_block.struct_name) {
+                clone->data.impl_block.struct_name = strdup(node->data.impl_block.struct_name);
+            }
+            clone->data.impl_block.methods = ast_node_list_clone_deep(node->data.impl_block.methods);
+            clone->data.impl_block.annotations = ast_node_list_clone_deep(node->data.impl_block.annotations);
+            break;
+            
+        case AST_METHOD_DECL:
+            if (node->data.method_decl.name) {
+                clone->data.method_decl.name = strdup(node->data.method_decl.name);
+            }
+            clone->data.method_decl.params = ast_node_list_clone_deep(node->data.method_decl.params);
+            clone->data.method_decl.return_type = ast_clone_node(node->data.method_decl.return_type);
+            clone->data.method_decl.body = ast_clone_node(node->data.method_decl.body);
+            clone->data.method_decl.is_instance_method = node->data.method_decl.is_instance_method;
+            clone->data.method_decl.visibility = node->data.method_decl.visibility;
+            clone->data.method_decl.annotations = ast_node_list_clone_deep(node->data.method_decl.annotations);
+            break;
+            
+        case AST_SPAWN_STMT:
+            if (node->data.spawn_stmt.function_name) {
+                clone->data.spawn_stmt.function_name = strdup(node->data.spawn_stmt.function_name);
+            }
+            clone->data.spawn_stmt.args = ast_node_list_clone_deep(node->data.spawn_stmt.args);
+            break;
+            
+        case AST_SPAWN_WITH_HANDLE_STMT:
+            if (node->data.spawn_with_handle_stmt.function_name) {
+                clone->data.spawn_with_handle_stmt.function_name = strdup(node->data.spawn_with_handle_stmt.function_name);
+            }
+            if (node->data.spawn_with_handle_stmt.handle_var_name) {
+                clone->data.spawn_with_handle_stmt.handle_var_name = strdup(node->data.spawn_with_handle_stmt.handle_var_name);
+            }
+            clone->data.spawn_with_handle_stmt.args = ast_node_list_clone_deep(node->data.spawn_with_handle_stmt.args);
+            break;
+            
+        case AST_STRUCT_PATTERN:
+            if (node->data.struct_pattern.struct_name) {
+                clone->data.struct_pattern.struct_name = strdup(node->data.struct_pattern.struct_name);
+            }
+            clone->data.struct_pattern.type_args = ast_node_list_clone_deep(node->data.struct_pattern.type_args);
+            clone->data.struct_pattern.field_patterns = ast_node_list_clone_deep(node->data.struct_pattern.field_patterns);
+            clone->data.struct_pattern.fields = ast_node_list_clone_deep(node->data.struct_pattern.fields);
+            clone->data.struct_pattern.is_partial = node->data.struct_pattern.is_partial;
+            break;
+            
+        case AST_TUPLE_PATTERN:
+            clone->data.tuple_pattern.patterns = ast_node_list_clone_deep(node->data.tuple_pattern.patterns);
+            break;
+            
+        case AST_EXTERN_DECL:
+            if (node->data.extern_decl.name) {
+                clone->data.extern_decl.name = strdup(node->data.extern_decl.name);
+            }
+            if (node->data.extern_decl.extern_name) {
+                clone->data.extern_decl.extern_name = strdup(node->data.extern_decl.extern_name);
+            }
+            clone->data.extern_decl.params = ast_node_list_clone_deep(node->data.extern_decl.params);
+            clone->data.extern_decl.return_type = ast_clone_node(node->data.extern_decl.return_type);
+            clone->data.extern_decl.annotations = ast_node_list_clone_deep(node->data.extern_decl.annotations);
+            break;
+            
+        case AST_PARAM_DECL:
+            if (node->data.param_decl.name) {
+                clone->data.param_decl.name = strdup(node->data.param_decl.name);
+            }
+            clone->data.param_decl.type = ast_clone_node(node->data.param_decl.type);
+            clone->data.param_decl.annotations = ast_node_list_clone_deep(node->data.param_decl.annotations);
+            break;
+            
+        case AST_CONST_DECL:
+            if (node->data.const_decl.name) {
+                clone->data.const_decl.name = strdup(node->data.const_decl.name);
+            }
+            clone->data.const_decl.type = ast_clone_node(node->data.const_decl.type);
+            clone->data.const_decl.value = ast_clone_node(node->data.const_decl.value);
+            clone->data.const_decl.visibility = node->data.const_decl.visibility;
+            clone->data.const_decl.annotations = ast_node_list_clone_deep(node->data.const_decl.annotations);
+            break;
+            
+        case AST_SEMANTIC_TAG:
+            if (node->data.semantic_tag.name) {
+                clone->data.semantic_tag.name = strdup(node->data.semantic_tag.name);
+            }
+            clone->data.semantic_tag.params = ast_node_list_clone_deep(node->data.semantic_tag.params);
+            break;
+            
+        case AST_STRUCT_TYPE:
+            if (node->data.struct_type.name) {
+                clone->data.struct_type.name = strdup(node->data.struct_type.name);
+            }
+            clone->data.struct_type.type_args = ast_node_list_clone_deep(node->data.struct_type.type_args);
+            break;
+            
+        case AST_ENUM_TYPE:
+            if (node->data.enum_type.name) {
+                clone->data.enum_type.name = strdup(node->data.enum_type.name);
+            }
+            clone->data.enum_type.type_args = ast_node_list_clone_deep(node->data.enum_type.type_args);
+            break;
+            
+        // Statement node types with child nodes
+        case AST_EXPR_STMT:
+            clone->data.expr_stmt.expression = ast_clone_node(node->data.expr_stmt.expression);
+            break;
+            
+        case AST_LET_STMT:
+            if (node->data.let_stmt.name) {
+                clone->data.let_stmt.name = strdup(node->data.let_stmt.name);
+            }
+            clone->data.let_stmt.type = ast_clone_node(node->data.let_stmt.type);
+            clone->data.let_stmt.initializer = ast_clone_node(node->data.let_stmt.initializer);
+            clone->data.let_stmt.is_mutable = node->data.let_stmt.is_mutable;
+            break;
+            
+        case AST_RETURN_STMT:
+            clone->data.return_stmt.expression = ast_clone_node(node->data.return_stmt.expression);
+            break;
+            
+        case AST_IF_STMT:
+            clone->data.if_stmt.condition = ast_clone_node(node->data.if_stmt.condition);
+            clone->data.if_stmt.then_block = ast_clone_node(node->data.if_stmt.then_block);
+            clone->data.if_stmt.else_block = ast_clone_node(node->data.if_stmt.else_block);
+            break;
+            
+        case AST_FOR_STMT:
+            if (node->data.for_stmt.variable) {
+                clone->data.for_stmt.variable = strdup(node->data.for_stmt.variable);
+            }
+            clone->data.for_stmt.iterable = ast_clone_node(node->data.for_stmt.iterable);
+            clone->data.for_stmt.body = ast_clone_node(node->data.for_stmt.body);
+            break;
+            
+        case AST_IF_LET_STMT:
+            clone->data.if_let_stmt.pattern = ast_clone_node(node->data.if_let_stmt.pattern);
+            clone->data.if_let_stmt.expression = ast_clone_node(node->data.if_let_stmt.expression);
+            clone->data.if_let_stmt.then_block = ast_clone_node(node->data.if_let_stmt.then_block);
+            clone->data.if_let_stmt.else_block = ast_clone_node(node->data.if_let_stmt.else_block);
+            break;
+            
+        case AST_UNSAFE_BLOCK:
+            clone->data.unsafe_block.block = ast_clone_node(node->data.unsafe_block.block);
+            break;
+            
+        // Expression node types with child nodes
+        case AST_FIELD_ACCESS:
+            clone->data.field_access.object = ast_clone_node(node->data.field_access.object);
+            if (node->data.field_access.field_name) {
+                clone->data.field_access.field_name = strdup(node->data.field_access.field_name);
+            }
+            break;
+            
+        case AST_INDEX_ACCESS:
+            clone->data.index_access.array = ast_clone_node(node->data.index_access.array);
+            clone->data.index_access.index = ast_clone_node(node->data.index_access.index);
+            break;
+            
+        case AST_SLICE_EXPR:
+            clone->data.slice_expr.array = ast_clone_node(node->data.slice_expr.array);
+            clone->data.slice_expr.start = ast_clone_node(node->data.slice_expr.start);
+            clone->data.slice_expr.end = ast_clone_node(node->data.slice_expr.end);
+            break;
+            
+        case AST_SLICE_LENGTH_ACCESS:
+            clone->data.slice_length_access.slice = ast_clone_node(node->data.slice_length_access.slice);
+            break;
+            
+        case AST_ASSIGNMENT:
+            clone->data.assignment.target = ast_clone_node(node->data.assignment.target);
+            clone->data.assignment.value = ast_clone_node(node->data.assignment.value);
+            break;
+            
+        case AST_AWAIT_EXPR:
+            clone->data.await_expr.task_handle_expr = ast_clone_node(node->data.await_expr.task_handle_expr);
+            clone->data.await_expr.timeout_expr = ast_clone_node(node->data.await_expr.timeout_expr);
+            break;
+            
+        // Type node types with child nodes
+        case AST_BASE_TYPE:
+            if (node->data.base_type.name) {
+                clone->data.base_type.name = strdup(node->data.base_type.name);
+            }
+            break;
+            
+        case AST_SLICE_TYPE:
+            clone->data.slice_type.element_type = ast_clone_node(node->data.slice_type.element_type);
+            break;
+            
+        case AST_ARRAY_TYPE:
+            clone->data.array_type.element_type = ast_clone_node(node->data.array_type.element_type);
+            clone->data.array_type.size = ast_clone_node(node->data.array_type.size);
+            break;
+            
+        case AST_PTR_TYPE:
+            clone->data.ptr_type.is_mutable = node->data.ptr_type.is_mutable;
+            clone->data.ptr_type.pointee_type = ast_clone_node(node->data.ptr_type.pointee_type);
+            break;
+            
+        case AST_RESULT_TYPE:
+            clone->data.result_type.ok_type = ast_clone_node(node->data.result_type.ok_type);
+            clone->data.result_type.err_type = ast_clone_node(node->data.result_type.err_type);
+            break;
+            
+        case AST_OPTION_TYPE:
+            clone->data.option_type.value_type = ast_clone_node(node->data.option_type.value_type);
+            break;
+            
+        // Pattern node types
+        case AST_MATCH_ARM:
+            clone->data.match_arm.pattern = ast_clone_node(node->data.match_arm.pattern);
+            clone->data.match_arm.body = ast_clone_node(node->data.match_arm.body);
+            clone->data.match_arm.guard = ast_clone_node(node->data.match_arm.guard);
+            break;
+            
+        case AST_ENUM_PATTERN:
+            if (node->data.enum_pattern.enum_name) {
+                clone->data.enum_pattern.enum_name = strdup(node->data.enum_pattern.enum_name);
+            }
+            if (node->data.enum_pattern.variant_name) {
+                clone->data.enum_pattern.variant_name = strdup(node->data.enum_pattern.variant_name);
+            }
+            if (node->data.enum_pattern.binding) {
+                clone->data.enum_pattern.binding = strdup(node->data.enum_pattern.binding);
+            }
+            break;
+            
+        case AST_FIELD_PATTERN:
+            if (node->data.field_pattern.field_name) {
+                clone->data.field_pattern.field_name = strdup(node->data.field_pattern.field_name);
+            }
+            if (node->data.field_pattern.binding_name) {
+                clone->data.field_pattern.binding_name = strdup(node->data.field_pattern.binding_name);
+            }
+            clone->data.field_pattern.is_ignored = node->data.field_pattern.is_ignored;
+            clone->data.field_pattern.pattern = ast_clone_node(node->data.field_pattern.pattern);
+            break;
+            
+        case AST_ENUM_VARIANT:
+            if (node->data.enum_variant.enum_name) {
+                clone->data.enum_variant.enum_name = strdup(node->data.enum_variant.enum_name);
+            }
+            if (node->data.enum_variant.variant_name) {
+                clone->data.enum_variant.variant_name = strdup(node->data.enum_variant.variant_name);
+            }
+            clone->data.enum_variant.value = ast_clone_node(node->data.enum_variant.value);
+            break;
+            
+        // Annotation node types
+        case AST_OWNERSHIP_TAG:
+            clone->data.ownership_tag.ownership = node->data.ownership_tag.ownership;
+            break;
+            
+        case AST_FFI_ANNOTATION:
+            clone->data.ffi_annotation.transfer_type = node->data.ffi_annotation.transfer_type;
+            break;
+            
+        case AST_SECURITY_TAG:
+            clone->data.security_tag.security_type = node->data.security_tag.security_type;
+            break;
+            
+        case AST_HUMAN_REVIEW_TAG:
+            clone->data.human_review_tag.priority = node->data.human_review_tag.priority;
+            break;
+            
+        case AST_VISIBILITY_MODIFIER:
+            clone->data.visibility_modifier.is_public = node->data.visibility_modifier.is_public;
+            break;
+            
+        case AST_STRUCT_FIELD:
+            if (node->data.struct_field.name) {
+                clone->data.struct_field.name = strdup(node->data.struct_field.name);
+            }
+            clone->data.struct_field.type = ast_clone_node(node->data.struct_field.type);
+            clone->data.struct_field.visibility = node->data.struct_field.visibility;
+            break;
+            
+        case AST_CONST_EXPR:
+            clone->data.const_expr.expr_type = node->data.const_expr.expr_type;
+            switch (node->data.const_expr.expr_type) {
+                case CONST_EXPR_LITERAL:
+                    clone->data.const_expr.data.literal = ast_clone_node(node->data.const_expr.data.literal);
+                    break;
+                case CONST_EXPR_BINARY_OP:
+                    clone->data.const_expr.data.binary.left = ast_clone_node(node->data.const_expr.data.binary.left);
+                    clone->data.const_expr.data.binary.op = node->data.const_expr.data.binary.op;
+                    clone->data.const_expr.data.binary.right = ast_clone_node(node->data.const_expr.data.binary.right);
+                    break;
+                case CONST_EXPR_UNARY_OP:
+                    clone->data.const_expr.data.unary.op = node->data.const_expr.data.unary.op;
+                    clone->data.const_expr.data.unary.operand = ast_clone_node(node->data.const_expr.data.unary.operand);
+                    break;
+                case CONST_EXPR_SIZEOF:
+                    clone->data.const_expr.data.sizeof_expr.type = ast_clone_node(node->data.const_expr.data.sizeof_expr.type);
+                    break;
+                case CONST_EXPR_IDENTIFIER:
+                    if (node->data.const_expr.data.identifier) {
+                        clone->data.const_expr.data.identifier = strdup(node->data.const_expr.data.identifier);
+                    }
+                    break;
+            }
+            break;
+            
+        case AST_BREAK_STMT:
+        case AST_CONTINUE_STMT:
+        case AST_WILDCARD_PATTERN:
+            // These have no data to clone
             break;
             
         // Add more cases as needed for other node types

--- a/src/parser/ast_node_list.h
+++ b/src/parser/ast_node_list.h
@@ -47,8 +47,11 @@ size_t ast_node_list_size(const ASTNodeList *list);
 // Clear all nodes from list
 void ast_node_list_clear(ASTNodeList *list);
 
-// Clone node list
+// Clone node list (shallow copy - retains existing nodes)
 ASTNodeList *ast_node_list_clone(const ASTNodeList *list);
+
+// Clone node list (deep copy - clones all nodes)
+ASTNodeList *ast_node_list_clone_deep(const ASTNodeList *list);
 
 #ifdef __cplusplus
 }

--- a/tests/parser/test_ast_deep_clone.c
+++ b/tests/parser/test_ast_deep_clone.c
@@ -1,0 +1,362 @@
+/**
+ * Asthra Programming Language Compiler
+ * Test: AST Deep Cloning
+ * 
+ * Tests deep cloning functionality for AST nodes, particularly
+ * for nodes containing ASTNodeList fields (struct literals, enums, etc.)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "../framework/test_framework.h"
+#include "../framework/compiler_test_utils.h"
+#include "parser.h"
+#include "ast.h"
+#include "ast_node_creation.h"
+#include "ast_node_list.h"
+
+// Test deep cloning of struct literal with type args and field inits
+static AsthraTestResult test_struct_literal_deep_clone(AsthraTestContext* context) {
+    // Create a struct literal node
+    ASTNode *original = ast_create_node(AST_STRUCT_LITERAL, (SourceLocation){0, 0});
+    ASTHRA_TEST_ASSERT(context, original != NULL, "Failed to create struct literal node");
+    
+    original->data.struct_literal.struct_name = strdup("Point");
+    
+    // Add type arguments
+    original->data.struct_literal.type_args = ast_node_list_create(2);
+    ASTNode *type_arg1 = ast_create_node(AST_BASE_TYPE, (SourceLocation){0, 0});
+    type_arg1->data.base_type.name = strdup("i32");
+    ast_node_list_add(&original->data.struct_literal.type_args, type_arg1);
+    
+    // Add field initializations
+    original->data.struct_literal.field_inits = ast_node_list_create(2);
+    
+    // Field init 1: x = 10
+    ASTNode *field_init1 = ast_create_node(AST_ASSIGNMENT, (SourceLocation){0, 0});
+    field_init1->data.assignment.target = ast_create_node(AST_IDENTIFIER, (SourceLocation){0, 0});
+    field_init1->data.assignment.target->data.identifier.name = strdup("x");
+    field_init1->data.assignment.value = ast_create_node(AST_INTEGER_LITERAL, (SourceLocation){0, 0});
+    field_init1->data.assignment.value->data.integer_literal.value = 10;
+    ast_node_list_add(&original->data.struct_literal.field_inits, field_init1);
+    
+    // Field init 2: y = 20
+    ASTNode *field_init2 = ast_create_node(AST_ASSIGNMENT, (SourceLocation){0, 0});
+    field_init2->data.assignment.target = ast_create_node(AST_IDENTIFIER, (SourceLocation){0, 0});
+    field_init2->data.assignment.target->data.identifier.name = strdup("y");
+    field_init2->data.assignment.value = ast_create_node(AST_INTEGER_LITERAL, (SourceLocation){0, 0});
+    field_init2->data.assignment.value->data.integer_literal.value = 20;
+    ast_node_list_add(&original->data.struct_literal.field_inits, field_init2);
+    
+    // Clone the node
+    ASTNode *clone = ast_clone_node(original);
+    ASTHRA_TEST_ASSERT(context, clone != NULL, "Failed to clone struct literal node");
+    
+    // Verify the clone
+    asthra_test_assert_int_eq(context, clone->type, AST_STRUCT_LITERAL, "Clone type mismatch");
+    asthra_test_assert_string_eq(context, clone->data.struct_literal.struct_name, "Point", "Struct name mismatch");
+    
+    // Verify type args are deep cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.struct_literal.type_args != NULL, "Type args not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.struct_literal.type_args != original->data.struct_literal.type_args, "Type args not deep cloned");
+    asthra_test_assert_size_eq(context, ast_node_list_size(clone->data.struct_literal.type_args), (size_t)1, "Type args count mismatch");
+    
+    ASTNode *cloned_type_arg = ast_node_list_get(clone->data.struct_literal.type_args, 0);
+    ASTHRA_TEST_ASSERT(context, cloned_type_arg != NULL, "Cloned type arg is null");
+    ASTHRA_TEST_ASSERT(context, cloned_type_arg != type_arg1, "Type arg not deep cloned");
+    asthra_test_assert_string_eq(context, cloned_type_arg->data.base_type.name, "i32", "Type arg name mismatch");
+    
+    // Verify field inits are deep cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.struct_literal.field_inits != NULL, "Field inits not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.struct_literal.field_inits != original->data.struct_literal.field_inits, "Field inits not deep cloned");
+    asthra_test_assert_size_eq(context, ast_node_list_size(clone->data.struct_literal.field_inits), (size_t)2, "Field inits count mismatch");
+    
+    // Check first field init
+    ASTNode *cloned_field1 = ast_node_list_get(clone->data.struct_literal.field_inits, 0);
+    ASTHRA_TEST_ASSERT(context, cloned_field1 != NULL, "First cloned field is null");
+    ASTHRA_TEST_ASSERT(context, cloned_field1 != field_init1, "First field not deep cloned");
+    asthra_test_assert_int_eq(context, cloned_field1->type, AST_ASSIGNMENT, "First field type mismatch");
+    asthra_test_assert_string_eq(context, cloned_field1->data.assignment.target->data.identifier.name, "x", "First field name mismatch");
+    asthra_test_assert_long_eq(context, cloned_field1->data.assignment.value->data.integer_literal.value, (int64_t)10, "First field value mismatch");
+    
+    // Check second field init
+    ASTNode *cloned_field2 = ast_node_list_get(clone->data.struct_literal.field_inits, 1);
+    ASTHRA_TEST_ASSERT(context, cloned_field2 != NULL, "Second cloned field is null");
+    ASTHRA_TEST_ASSERT(context, cloned_field2 != field_init2, "Second field not deep cloned");
+    asthra_test_assert_int_eq(context, cloned_field2->type, AST_ASSIGNMENT, "Second field type mismatch");
+    asthra_test_assert_string_eq(context, cloned_field2->data.assignment.target->data.identifier.name, "y", "Second field name mismatch");
+    asthra_test_assert_long_eq(context, cloned_field2->data.assignment.value->data.integer_literal.value, (int64_t)20, "Second field value mismatch");
+    
+    // Clean up
+    ast_free_node(original);
+    ast_free_node(clone);
+    
+    return ASTHRA_TEST_PASS;
+}
+
+// Test deep cloning of enum declaration
+static AsthraTestResult test_enum_decl_deep_clone(AsthraTestContext* context) {
+    // Create an enum declaration node
+    ASTNode *original = ast_create_node(AST_ENUM_DECL, (SourceLocation){0, 0});
+    ASTHRA_TEST_ASSERT(context, original != NULL, "Failed to create enum declaration node");
+    
+    original->data.enum_decl.name = strdup("Option");
+    original->data.enum_decl.visibility = VISIBILITY_PUBLIC;
+    
+    // Add type parameters
+    original->data.enum_decl.type_params = ast_node_list_create(1);
+    ASTNode *type_param = ast_create_node(AST_IDENTIFIER, (SourceLocation){0, 0});
+    type_param->data.identifier.name = strdup("T");
+    ast_node_list_add(&original->data.enum_decl.type_params, type_param);
+    
+    // Add variants
+    original->data.enum_decl.variants = ast_node_list_create(2);
+    
+    // Variant 1: Some(T)
+    ASTNode *variant1 = ast_create_node(AST_ENUM_VARIANT_DECL, (SourceLocation){0, 0});
+    variant1->data.enum_variant_decl.name = strdup("Some");
+    variant1->data.enum_variant_decl.associated_type = ast_create_node(AST_IDENTIFIER, (SourceLocation){0, 0});
+    variant1->data.enum_variant_decl.associated_type->data.identifier.name = strdup("T");
+    ast_node_list_add(&original->data.enum_decl.variants, variant1);
+    
+    // Variant 2: None
+    ASTNode *variant2 = ast_create_node(AST_ENUM_VARIANT_DECL, (SourceLocation){0, 0});
+    variant2->data.enum_variant_decl.name = strdup("None");
+    ast_node_list_add(&original->data.enum_decl.variants, variant2);
+    
+    // Add annotations
+    original->data.enum_decl.annotations = ast_node_list_create(1);
+    ASTNode *annotation = ast_create_node(AST_OWNERSHIP_TAG, (SourceLocation){0, 0});
+    annotation->data.ownership_tag.ownership = OWNERSHIP_GC;
+    ast_node_list_add(&original->data.enum_decl.annotations, annotation);
+    
+    // Clone the node
+    ASTNode *clone = ast_clone_node(original);
+    ASTHRA_TEST_ASSERT(context, clone != NULL, "Failed to clone enum declaration node");
+    
+    // Verify the clone
+    asthra_test_assert_int_eq(context, clone->type, AST_ENUM_DECL, "Clone type mismatch");
+    asthra_test_assert_string_eq(context, clone->data.enum_decl.name, "Option", "Enum name mismatch");
+    asthra_test_assert_int_eq(context, (int)clone->data.enum_decl.visibility, (int)VISIBILITY_PUBLIC, "Visibility mismatch");
+    
+    // Verify type params are deep cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.enum_decl.type_params != NULL, "Type params not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.enum_decl.type_params != original->data.enum_decl.type_params, "Type params not deep cloned");
+    asthra_test_assert_size_eq(context, ast_node_list_size(clone->data.enum_decl.type_params), (size_t)1, "Type params count mismatch");
+    
+    // Verify variants are deep cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.enum_decl.variants != NULL, "Variants not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.enum_decl.variants != original->data.enum_decl.variants, "Variants not deep cloned");
+    asthra_test_assert_size_eq(context, ast_node_list_size(clone->data.enum_decl.variants), (size_t)2, "Variants count mismatch");
+    
+    // Check first variant
+    ASTNode *cloned_variant1 = ast_node_list_get(clone->data.enum_decl.variants, 0);
+    ASTHRA_TEST_ASSERT(context, cloned_variant1 != NULL, "First cloned variant is null");
+    ASTHRA_TEST_ASSERT(context, cloned_variant1 != variant1, "First variant not deep cloned");
+    asthra_test_assert_string_eq(context, cloned_variant1->data.enum_variant_decl.name, "Some", "Variant name mismatch");
+    ASTHRA_TEST_ASSERT(context, cloned_variant1->data.enum_variant_decl.associated_type != NULL, "Associated type not cloned");
+    asthra_test_assert_string_eq(context, cloned_variant1->data.enum_variant_decl.associated_type->data.identifier.name, "T", "Associated type name mismatch");
+    
+    // Verify annotations are deep cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.enum_decl.annotations != NULL, "Annotations not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.enum_decl.annotations != original->data.enum_decl.annotations, "Annotations not deep cloned");
+    asthra_test_assert_size_eq(context, ast_node_list_size(clone->data.enum_decl.annotations), (size_t)1, "Annotations count mismatch");
+    
+    // Clean up
+    ast_free_node(original);
+    ast_free_node(clone);
+    
+    return ASTHRA_TEST_PASS;
+}
+
+// Test deep cloning of function declaration
+static AsthraTestResult test_function_decl_deep_clone(AsthraTestContext* context) {
+    // Create a function declaration node
+    ASTNode *original = ast_create_node(AST_FUNCTION_DECL, (SourceLocation){0, 0});
+    ASTHRA_TEST_ASSERT(context, original != NULL, "Failed to create function declaration node");
+    
+    original->data.function_decl.name = strdup("calculate");
+    original->data.function_decl.visibility = VISIBILITY_PUBLIC;
+    
+    // Add parameters
+    original->data.function_decl.params = ast_node_list_create(2);
+    
+    ASTNode *param1 = ast_create_node(AST_PARAM_DECL, (SourceLocation){0, 0});
+    param1->data.param_decl.name = strdup("x");
+    param1->data.param_decl.type = ast_create_node(AST_BASE_TYPE, (SourceLocation){0, 0});
+    param1->data.param_decl.type->data.base_type.name = strdup("i32");
+    ast_node_list_add(&original->data.function_decl.params, param1);
+    
+    ASTNode *param2 = ast_create_node(AST_PARAM_DECL, (SourceLocation){0, 0});
+    param2->data.param_decl.name = strdup("y");
+    param2->data.param_decl.type = ast_create_node(AST_BASE_TYPE, (SourceLocation){0, 0});
+    param2->data.param_decl.type->data.base_type.name = strdup("i32");
+    ast_node_list_add(&original->data.function_decl.params, param2);
+    
+    // Set return type
+    original->data.function_decl.return_type = ast_create_node(AST_BASE_TYPE, (SourceLocation){0, 0});
+    original->data.function_decl.return_type->data.base_type.name = strdup("i32");
+    
+    // Set body
+    original->data.function_decl.body = ast_create_node(AST_BLOCK, (SourceLocation){0, 0});
+    original->data.function_decl.body->data.block.statements = ast_node_list_create(1);
+    
+    // Clone the node
+    ASTNode *clone = ast_clone_node(original);
+    ASTHRA_TEST_ASSERT(context, clone != NULL, "Failed to clone function declaration node");
+    
+    // Verify the clone
+    asthra_test_assert_int_eq(context, clone->type, AST_FUNCTION_DECL, "Clone type mismatch");
+    asthra_test_assert_string_eq(context, clone->data.function_decl.name, "calculate", "Function name mismatch");
+    asthra_test_assert_int_eq(context, (int)clone->data.function_decl.visibility, (int)VISIBILITY_PUBLIC, "Visibility mismatch");
+    
+    // Verify params are deep cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.params != NULL, "Params not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.params != original->data.function_decl.params, "Params not deep cloned");
+    asthra_test_assert_size_eq(context, ast_node_list_size(clone->data.function_decl.params), (size_t)2, "Params count mismatch");
+    
+    // Verify return type is cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.return_type != NULL, "Return type not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.return_type != original->data.function_decl.return_type, "Return type not deep cloned");
+    asthra_test_assert_string_eq(context, clone->data.function_decl.return_type->data.base_type.name, "i32", "Return type name mismatch");
+    
+    // Verify body is cloned
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.body != NULL, "Body not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.body != original->data.function_decl.body, "Body not deep cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.body->data.block.statements != NULL, "Body statements not cloned");
+    ASTHRA_TEST_ASSERT(context, clone->data.function_decl.body->data.block.statements != 
+                         original->data.function_decl.body->data.block.statements, "Body statements not deep cloned");
+    
+    // Clean up
+    ast_free_node(original);
+    ast_free_node(clone);
+    
+    return ASTHRA_TEST_PASS;
+}
+
+// Test that modifying cloned lists doesn't affect original
+static AsthraTestResult test_clone_independence(AsthraTestContext* context) {
+    // Create an array literal
+    ASTNode *original = ast_create_node(AST_ARRAY_LITERAL, (SourceLocation){0, 0});
+    ASTHRA_TEST_ASSERT(context, original != NULL, "Failed to create array literal node");
+    
+    original->data.array_literal.elements = ast_node_list_create(2);
+    
+    ASTNode *elem1 = ast_create_node(AST_INTEGER_LITERAL, (SourceLocation){0, 0});
+    elem1->data.integer_literal.value = 1;
+    ast_node_list_add(&original->data.array_literal.elements, elem1);
+    
+    ASTNode *elem2 = ast_create_node(AST_INTEGER_LITERAL, (SourceLocation){0, 0});
+    elem2->data.integer_literal.value = 2;
+    ast_node_list_add(&original->data.array_literal.elements, elem2);
+    
+    // Clone the node
+    ASTNode *clone = ast_clone_node(original);
+    ASTHRA_TEST_ASSERT(context, clone != NULL, "Failed to clone array literal node");
+    
+    // Modify the clone by adding another element
+    ASTNode *elem3 = ast_create_node(AST_INTEGER_LITERAL, (SourceLocation){0, 0});
+    elem3->data.integer_literal.value = 3;
+    ast_node_list_add(&clone->data.array_literal.elements, elem3);
+    
+    // Verify original is unchanged
+    asthra_test_assert_size_eq(context, ast_node_list_size(original->data.array_literal.elements), (size_t)2, "Original was modified");
+    asthra_test_assert_size_eq(context, ast_node_list_size(clone->data.array_literal.elements), (size_t)3, "Clone was not modified");
+    
+    // Modify an element in the clone
+    ASTNode *cloned_elem1 = ast_node_list_get(clone->data.array_literal.elements, 0);
+    cloned_elem1->data.integer_literal.value = 100;
+    
+    // Verify original element is unchanged
+    ASTNode *orig_elem1 = ast_node_list_get(original->data.array_literal.elements, 0);
+    asthra_test_assert_long_eq(context, orig_elem1->data.integer_literal.value, (int64_t)1, "Original element was modified");
+    asthra_test_assert_long_eq(context, cloned_elem1->data.integer_literal.value, (int64_t)100, "Clone element was not modified");
+    
+    // Clean up
+    ast_free_node(original);
+    ast_free_node(clone);
+    
+    return ASTHRA_TEST_PASS;
+}
+
+// =============================================================================
+// TEST SUITE DEFINITION
+// =============================================================================
+
+int main(int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+    
+    // Initialize test framework
+    AsthraTestStatistics *stats = asthra_test_statistics_create();
+    if (!stats) {
+        fprintf(stderr, "Failed to create test statistics\n");
+        return 1;
+    }
+    
+    AsthraTestMetadata metadata = {
+        .name = "AST Deep Clone Tests",
+        .file = __FILE__,
+        .line = __LINE__,
+        .function = "main",
+        .severity = ASTHRA_TEST_SEVERITY_CRITICAL,
+        .timeout_ns = 30000000000ULL,
+        .skip = false,
+        .skip_reason = NULL
+    };
+    
+    AsthraTestContext *context = asthra_test_context_create(&metadata, stats);
+    if (!context) {
+        fprintf(stderr, "Failed to create test context\n");
+        asthra_test_statistics_destroy(stats);
+        return 1;
+    }
+    
+    printf("Running AST Deep Clone Tests...\n\n");
+    
+    // Run all tests
+    AsthraTestResult result1 = test_struct_literal_deep_clone(context);
+    AsthraTestResult result2 = test_enum_decl_deep_clone(context);
+    AsthraTestResult result3 = test_function_decl_deep_clone(context);
+    AsthraTestResult result4 = test_clone_independence(context);
+    
+    // Calculate results
+    int passed = 0;
+    int total = 4;
+    
+    if (result1 == ASTHRA_TEST_PASS) {
+        printf("[PASS] test_struct_literal_deep_clone\n");
+        passed++;
+    } else {
+        printf("[FAIL] test_struct_literal_deep_clone\n");
+    }
+    
+    if (result2 == ASTHRA_TEST_PASS) {
+        printf("[PASS] test_enum_decl_deep_clone\n");
+        passed++;
+    } else {
+        printf("[FAIL] test_enum_decl_deep_clone\n");
+    }
+    
+    if (result3 == ASTHRA_TEST_PASS) {
+        printf("[PASS] test_function_decl_deep_clone\n");
+        passed++;
+    } else {
+        printf("[FAIL] test_function_decl_deep_clone\n");
+    }
+    
+    if (result4 == ASTHRA_TEST_PASS) {
+        printf("[PASS] test_clone_independence\n");
+        passed++;
+    } else {
+        printf("[FAIL] test_clone_independence\n");
+    }
+    
+    printf("\nTest Results: %d/%d passed\n", passed, total);
+    
+    asthra_test_context_destroy(context);
+    asthra_test_statistics_destroy(stats);
+    return (passed == total) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
This PR fixes issue #35 by implementing proper deep cloning for AST nodes that contain ASTNodeList fields. Previously, these fields were shallow copied, which could lead to memory management issues and incorrect AST modifications.

## Changes
- Added `ast_node_list_clone_deep()` function to perform deep cloning of node lists
- Updated `ast_clone_node()` to handle all AST node types with ASTNodeList fields:
  - Struct literals (type_args, field_inits)
  - Enum declarations (variants, type_params, annotations)
  - Function declarations (params, annotations)
  - Blocks (statements)
  - Arrays (elements)
  - And many more...
- Added comprehensive test coverage in `test_ast_deep_clone.c`

## Test Results
All tests pass, including the new deep clone tests:
```
Running AST Deep Clone Tests...

[PASS] test_struct_literal_deep_clone
[PASS] test_enum_decl_deep_clone
[PASS] test_function_decl_deep_clone
[PASS] test_clone_independence

Test Results: 4/4 passed
```

## Impact
This change ensures that cloned AST nodes are completely independent from their originals, preventing:
- Memory corruption from shared pointers
- Unintended modifications to original AST nodes
- Reference counting issues

Closes #35

🤖 Generated with [Claude Code](https://claude.ai/code)