### PR TITLE
feat(testing): setup BDD testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,24 @@ coverage_*.txt
 */summary.csv
 summary.txt
 
+# BDD Test artifacts
+bdd/bin/
+bdd/build/
+bdd/test-results/
+bdd/**/*.o
+bdd/**/*.d
+bdd/**/*.gcov
+bdd/**/*.gcda
+bdd/**/*.gcno
+bdd/fixtures/*.out
+bdd/fixtures/*.tmp
+bdd-results.xml
+bdd-report*.html
+bdd-report*.json
+*.feature.log
+*_steps.o
+*_steps.d
+
 # Documentation build
 docs/build/
 docs/_build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ include(cmake/Installation.cmake)  # Install/uninstall/dist targets
 include(cmake/BuildInfo.cmake)     # Build information display
 include(cmake/Help.cmake)          # Comprehensive help
 
+# Build options
+option(BUILD_BDD_TESTS "Build BDD (Behavior-Driven Development) tests" OFF)
+
 # Global configuration
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -52,6 +55,11 @@ add_subdirectory(runtime)
 add_subdirectory(stdlib)
 add_subdirectory(tools)
 add_subdirectory(tests)
+
+# Add BDD tests if enabled
+if(BUILD_BDD_TESTS)
+    add_subdirectory(bdd)
+endif()
 
 # Include interim test runner
 include(cmake/TestRunner.cmake)

--- a/bdd/CMakeLists.txt
+++ b/bdd/CMakeLists.txt
@@ -1,0 +1,132 @@
+# BDD Testing Infrastructure for Asthra
+# Provides Behavior-Driven Development testing framework
+
+message(STATUS "Configuring BDD testing infrastructure")
+
+# BDD test output directory
+set(BDD_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin)
+file(MAKE_DIRECTORY ${BDD_OUTPUT_DIR})
+
+# Set BDD-specific output directories
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${BDD_OUTPUT_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib)
+
+# BDD test categories
+set(BDD_TEST_CATEGORIES
+    acceptance
+    integration
+    scenario
+    feature
+)
+
+# Include directories for BDD tests
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}/steps
+    ${CMAKE_CURRENT_SOURCE_DIR}/support
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/runtime
+    ${PROJECT_SOURCE_DIR}/tests/framework
+)
+
+# Function to add BDD test executable
+function(add_bdd_test name category)
+    set(test_target bdd_${category}_${name})
+    
+    # Collect source files
+    file(GLOB step_sources 
+        ${CMAKE_CURRENT_SOURCE_DIR}/steps/${category}/${name}_steps.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/steps/${category}/common_steps.c
+    )
+    
+    file(GLOB support_sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/support/*.c
+    )
+    
+    # Create test executable
+    add_executable(${test_target} 
+        ${step_sources}
+        ${support_sources}
+    )
+    
+    # Link with Asthra runtime and test framework
+    target_link_libraries(${test_target}
+        asthra_runtime
+        test_framework
+    )
+    
+    # Set output directory
+    set_target_properties(${test_target} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY ${BDD_OUTPUT_DIR}
+    )
+    
+    # Add to CTest
+    add_test(NAME ${test_target} 
+        COMMAND ${test_target}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    
+    # Set test properties
+    set_tests_properties(${test_target} PROPERTIES
+        LABELS "bdd;${category}"
+        TIMEOUT 60
+        ENVIRONMENT "BDD_FEATURES_DIR=${CMAKE_CURRENT_SOURCE_DIR}/features"
+    )
+    
+    # Add to build-tests target
+    add_dependencies(build-tests ${test_target})
+endfunction()
+
+# Create BDD test targets
+add_custom_target(bdd-tests
+    COMMAND ${CMAKE_CTEST_COMMAND} 
+            --output-on-failure
+            --label-regex "^bdd$"
+    COMMENT "Running all BDD tests"
+    USES_TERMINAL
+)
+
+# Category-specific BDD test targets
+foreach(category ${BDD_TEST_CATEGORIES})
+    add_custom_target(bdd-${category}
+        COMMAND ${CMAKE_CTEST_COMMAND}
+                --output-on-failure
+                --label-regex "bdd.*${category}"
+        COMMENT "Running BDD ${category} tests"
+        USES_TERMINAL
+    )
+endforeach()
+
+# BDD test runner with Gherkin support
+add_custom_target(bdd-run
+    COMMAND ${CMAKE_COMMAND} -E echo "Running BDD tests with Gherkin features..."
+    COMMAND ${CMAKE_CTEST_COMMAND}
+            --output-on-failure
+            --label-regex "^bdd$"
+            --verbose
+    COMMENT "Run BDD tests with verbose output"
+    USES_TERMINAL
+)
+
+# Generate BDD test report
+add_custom_target(bdd-report
+    COMMAND ${CMAKE_CTEST_COMMAND}
+            --output-on-failure
+            --label-regex "^bdd$"
+            --output-junit ${CMAKE_CURRENT_BINARY_DIR}/bdd-results.xml
+    COMMENT "Generate BDD test report"
+)
+
+# Clean BDD test outputs
+add_custom_target(bdd-clean
+    COMMAND ${CMAKE_COMMAND} -E remove_directory ${BDD_OUTPUT_DIR}
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${BDD_OUTPUT_DIR}
+    COMMENT "Clean BDD test outputs"
+)
+
+# Note: Individual BDD tests will be added as feature files and step definitions are created
+# Example usage:
+# add_bdd_test(user_login acceptance)
+# add_bdd_test(compiler_workflow integration)
+
+message(STATUS "BDD testing infrastructure configured")


### PR DESCRIPTION
## Summary
- Implements the foundation for Behavior-Driven Development (BDD) testing framework for the Asthra compiler
- Creates all required infrastructure to support BDD testing with Gherkin feature files

## Changes
- ✅ Add BUILD_BDD_TESTS CMake option to enable/disable BDD testing
- ✅ Create organized BDD directory structure:
  - `bdd/features/` - For Gherkin feature files
  - `bdd/steps/` - For C step definitions
  - `bdd/support/` - For test helpers
  - `bdd/fixtures/` - For sample source files
  - `bdd/bin/` - For generated test executables
- ✅ Add comprehensive `bdd/CMakeLists.txt` with:
  - BDD test configuration
  - Category-based test organization
  - Custom targets for running BDD tests
  - Infrastructure for future test additions
- ✅ Update `.gitignore` with BDD-specific patterns to ignore generated artifacts

## Testing
- Built with `-DBUILD_BDD_TESTS=ON` successfully
- All existing tests continue to pass
- BDD infrastructure is ready for feature files and step definitions

Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)