### PR TITLE
chore(ci): update CGreen to version 1.6.3 in BDD workflow

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -73,9 +73,9 @@ jobs:
         # Install Cgreen testing framework
         sudo apt-get install -y libcgreen1-dev || {
           echo "Installing Cgreen from source..."
-          wget https://github.com/cgreen-devs/cgreen/releases/download/1.6.2/cgreen-1.6.2.tar.gz
-          tar xzf cgreen-1.6.2.tar.gz
-          cd cgreen-1.6.2
+          wget https://github.com/cgreen-devs/cgreen/archive/refs/tags/1.6.3.tar.gz
+          tar xzf 1.6.3.tar.gz
+          cd cgreen-1.6.3
           mkdir build && cd build
           cmake .. && make
           sudo make install
@@ -106,9 +106,9 @@ jobs:
         # Install Cgreen
         brew install cgreen || {
           echo "Installing Cgreen from source..."
-          wget https://github.com/cgreen-devs/cgreen/releases/download/1.6.2/cgreen-1.6.2.tar.gz
-          tar xzf cgreen-1.6.2.tar.gz
-          cd cgreen-1.6.2
+          wget https://github.com/cgreen-devs/cgreen/archive/refs/tags/1.6.3.tar.gz
+          tar xzf 1.6.3.tar.gz
+          cd cgreen-1.6.3
           mkdir build && cd build
           cmake .. && make
           sudo make install


### PR DESCRIPTION
## Summary
- Updated CGreen testing framework from v1.6.2 to v1.6.3
- Changed download URL to use GitHub archive format (`https://github.com/cgreen-devs/cgreen/archive/refs/tags/1.6.3.tar.gz`)
- Applied changes to both Linux and macOS installation steps

## Test plan
- [ ] Verify BDD workflow runs successfully on Linux
- [ ] Verify BDD workflow runs successfully on macOS
- [ ] Confirm CGreen 1.6.3 installs correctly from the archive URL

🤖 Generated with [Claude Code](https://claude.ai/code)