### PR TITLE
test: verify struct field visibility implementation status

### DIFF
--- a/docs/contributor/grammar-implementation-gaps.md
+++ b/docs/contributor/grammar-implementation-gaps.md
@@ -85,10 +85,15 @@ These are grammar features that may need reconsideration:
 - **Status**: Basic patterns work, but complex nested patterns may have gaps
 - **Example**: `let (a, (b, c)) = nested_tuple;` - nested tuple patterns
 
-#### Field Visibility in Structs
+#### Field Visibility in Structs ⚠️ PARTIALLY IMPLEMENTED
 - **Grammar**: Line 46: `StructField <- VisibilityModifier? SimpleIdent ':' Type`
-- **Status**: Grammar allows visibility modifiers on struct fields
-- **Testing**: Need to verify if field-level visibility is enforced
+- **Status**: ⚠️ PARSED BUT NOT ENFORCED
+- **Parser**: Fully implemented - correctly extracts `pub`/`priv` modifiers
+- **Semantic**: NOT enforced - has TODO comment in `semantic_structs_visibility.c`
+- **Issue**: All fields are effectively public regardless of modifier
+- **Test Coverage**: Parser tests pass, semantic tests document lack of enforcement
+- **Documentation**: See `docs/contributor/struct-field-visibility-analysis.md`
+- **Test Branch**: test/struct-field-visibility
 
 #### Repeated Array Elements ✅ TESTED
 - **Grammar**: Line 155: `RepeatedElements <- ConstExpr ';' ConstExpr` (e.g., `[0; 100]`)

--- a/docs/contributor/struct-field-visibility-analysis.md
+++ b/docs/contributor/struct-field-visibility-analysis.md
@@ -1,0 +1,118 @@
+# Struct Field Visibility Implementation Analysis
+
+## Summary
+Struct field visibility modifiers (`pub` and `priv`) are defined in the grammar and correctly parsed, but visibility enforcement is NOT implemented in the semantic analyzer.
+
+## Grammar Definition
+```
+StructField <- VisibilityModifier? SimpleIdent ':' Type  # Line 46
+VisibilityModifier <- 'pub' / 'priv'                    # Line 10
+```
+
+## Current Implementation Status
+
+### ✅ Parser Implementation (COMPLETE)
+- **Location**: `src/parser/grammar_toplevel_struct.c`
+- **Lines 123-131**: Correctly parses visibility modifiers
+- **Lines 186**: Stores visibility in AST node as `field->data.struct_field.visibility`
+- **Default**: Fields without explicit modifier default to `VISIBILITY_PRIVATE`
+
+### ❌ Semantic Analysis (INCOMPLETE)
+- **Visibility Checking**: `src/analysis/semantic_structs_visibility.c`
+- **Lines 47-50**: Contains TODO comment - visibility NOT enforced
+- **Current Behavior**: All fields accessible regardless of visibility modifier
+- **Symbol Table**: Visibility field exists in `SymbolEntry` but not populated
+
+## Key Findings
+
+### 1. Parser Correctly Extracts Visibility
+```c
+// From grammar_toplevel_struct.c
+VisibilityType field_visibility = VISIBILITY_PRIVATE;
+if (match_token(parser, TOKEN_PUB)) {
+    field_visibility = VISIBILITY_PUBLIC;
+    advance_token(parser);
+} else if (match_token(parser, TOKEN_PRIV)) {
+    field_visibility = VISIBILITY_PRIVATE;
+    advance_token(parser);
+}
+```
+
+### 2. Semantic Analyzer Has Infrastructure but No Implementation
+```c
+// From semantic_structs_visibility.c
+if (field_symbol->visibility == VISIBILITY_PRIVATE) {
+    // TODO: Check if we're in the same package/module
+    // For now, we'll allow private access (should be restricted in real implementation)
+}
+```
+
+### 3. Symbol Entry Missing Visibility Assignment
+- `symbol_entry_create()` doesn't extract visibility from AST node
+- Field symbols created without visibility information
+- The `SymbolEntry` structure has a `visibility` field but it's never set
+
+## Test Results
+
+### Parser Tests (All Pass ✅)
+1. Public fields parsed with correct visibility
+2. Private fields parsed with correct visibility
+3. Mixed visibility fields handled correctly
+4. Default visibility (private) applied when no modifier
+5. Visibility works with complex types and generics
+6. Empty structs handled correctly
+
+### Semantic Tests (Document Current Behavior 📝)
+1. Public field access - works (as expected)
+2. Private field access - works (should be blocked)
+3. Default private fields - accessible (should be blocked)
+4. Cross-struct private access - works (should be blocked)
+5. Methods can access own private fields - works (correct)
+
+## Implementation Gap
+
+### What's Missing
+1. **Symbol Table Population**: When creating field symbols, visibility from AST node needs to be copied to symbol entry
+2. **Access Checking**: The TODO in `check_field_visibility()` needs implementation
+3. **Package/Module Context**: Need to determine access rules (same package? same module?)
+
+### Required Changes
+1. In `semantic_structs_declaration.c` around line 161:
+   ```c
+   SymbolEntry *field_symbol = symbol_entry_create(field_name, SYMBOL_FIELD, field_type, field);
+   if (field_symbol) {
+       // ADD: Extract visibility from AST node
+       field_symbol->visibility = field->data.struct_field.visibility;
+   }
+   ```
+
+2. In `semantic_structs_visibility.c` implement the TODO:
+   - Check if access is from same struct (methods)
+   - Check if access is from same package/module
+   - Report error for unauthorized private field access
+
+## Impact Assessment
+
+### Current State
+- **Syntax**: ✅ Fully supported
+- **Parser**: ✅ Fully implemented
+- **Semantic**: ❌ Not enforced
+- **Runtime**: N/A (compile-time feature)
+
+### User Impact
+- Users can write visibility modifiers
+- Modifiers are recognized but not enforced
+- All fields are effectively public at runtime
+
+## Recommendation
+
+This is a **partially implemented feature** that needs completion in the semantic analyzer. The infrastructure exists but enforcement is missing. Priority should be:
+1. Medium - Complete semantic enforcement
+2. Low - Define clear access rules for packages/modules
+
+## Related Files
+- Grammar: `grammar.txt` lines 10, 46
+- Parser: `src/parser/grammar_toplevel_struct.c`
+- Semantic: `src/analysis/semantic_structs_visibility.c`
+- Semantic: `src/analysis/semantic_structs_declaration.c`
+- Types: `src/analysis/semantic_symbols_defs.h` (SymbolEntry structure)

--- a/tests/parser/test_struct_field_visibility.c
+++ b/tests/parser/test_struct_field_visibility.c
@@ -1,0 +1,396 @@
+/**
+ * Comprehensive test suite for struct field visibility verification
+ * Tests visibility modifiers on struct fields as defined in grammar.txt line 46
+ * 
+ * Copyright (c) 2024 Asthra Project
+ * Licensed under the terms specified in LICENSE
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "../../src/parser/lexer.h"
+#include "../../src/parser/parser.h"
+#include "../../src/parser/ast.h"
+#include "../../src/parser/ast_node_list.h"
+
+// Helper function to create parser from source
+static Parser* create_parser(const char* source) {
+    Lexer* lexer = lexer_create(source, strlen(source), "<test>");
+    if (!lexer) return NULL;
+    
+    Parser* parser = parser_create(lexer);
+    return parser;
+}
+
+// Test 1: Basic public field
+void test_public_field(void) {
+    printf("Testing public field visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Point {\n"
+        "    pub x: i32,\n"
+        "    pub y: i32\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    assert(program->type == AST_PROGRAM);
+    
+    // Navigate to struct declaration
+    ASTNodeList* decls = program->data.program.declarations;
+    assert(decls && decls->count == 1);
+    
+    ASTNode* struct_decl = decls->nodes[0];
+    assert(struct_decl->type == AST_STRUCT_DECL);
+    assert(strcmp(struct_decl->data.struct_decl.name, "Point") == 0);
+    
+    // Check fields
+    ASTNodeList* fields = struct_decl->data.struct_decl.fields;
+    assert(fields && ast_node_list_size(fields) == 2);
+    
+    // Check first field (x)
+    ASTNode* field_x = ast_node_list_get(fields, 0);
+    assert(field_x->type == AST_STRUCT_FIELD);
+    assert(strcmp(field_x->data.struct_field.name, "x") == 0);
+    assert(field_x->data.struct_field.visibility == VISIBILITY_PUBLIC);
+    
+    // Check second field (y)
+    ASTNode* field_y = ast_node_list_get(fields, 1);
+    assert(field_y->type == AST_STRUCT_FIELD);
+    assert(strcmp(field_y->data.struct_field.name, "y") == 0);
+    assert(field_y->data.struct_field.visibility == VISIBILITY_PUBLIC);
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Public fields parsed correctly with visibility\n");
+}
+
+// Test 2: Basic private field
+void test_private_field(void) {
+    printf("Testing private field visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct BankAccount {\n"
+        "    priv balance: f64,\n"
+        "    priv pin: i32\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    ASTNode* struct_decl = decls->nodes[0];
+    ASTNodeList* fields = struct_decl->data.struct_decl.fields;
+    assert(fields && ast_node_list_size(fields) == 2);
+    
+    // Check private fields
+    ASTNode* field_balance = ast_node_list_get(fields, 0);
+    assert(field_balance->data.struct_field.visibility == VISIBILITY_PRIVATE);
+    
+    ASTNode* field_pin = ast_node_list_get(fields, 1);
+    assert(field_pin->data.struct_field.visibility == VISIBILITY_PRIVATE);
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Private fields parsed correctly with visibility\n");
+}
+
+// Test 3: Mixed visibility fields
+void test_mixed_visibility_fields(void) {
+    printf("Testing mixed visibility fields ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct User {\n"
+        "    pub id: i32,\n"
+        "    pub username: string,\n"
+        "    priv password_hash: string,\n"
+        "    priv email: string,\n"
+        "    pub created_at: i64\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    ASTNode* struct_decl = decls->nodes[0];
+    ASTNodeList* fields = struct_decl->data.struct_decl.fields;
+    assert(ast_node_list_size(fields) == 5);
+    
+    // Verify visibility of each field
+    assert(ast_node_list_get(fields, 0)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // id
+    assert(ast_node_list_get(fields, 1)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // username
+    assert(ast_node_list_get(fields, 2)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // password_hash
+    assert(ast_node_list_get(fields, 3)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // email
+    assert(ast_node_list_get(fields, 4)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // created_at
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Mixed visibility fields parsed correctly\n");
+}
+
+// Test 4: Default visibility (no modifier)
+void test_default_visibility(void) {
+    printf("Testing default field visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Config {\n"
+        "    timeout: i32,\n"
+        "    retries: i32,\n"
+        "    pub verbose: bool\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    ASTNode* struct_decl = decls->nodes[0];
+    ASTNodeList* fields = struct_decl->data.struct_decl.fields;
+    
+    // Fields without explicit visibility should default to private
+    assert(ast_node_list_get(fields, 0)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // timeout
+    assert(ast_node_list_get(fields, 1)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // retries
+    assert(ast_node_list_get(fields, 2)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // verbose
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Default visibility (private) parsed correctly\n");
+}
+
+// Test 5: Complex types with visibility
+void test_visibility_with_complex_types(void) {
+    printf("Testing visibility with complex types ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Database {\n"
+        "    pub connections: Vec<Connection>,\n"
+        "    priv credentials: Map<string, string>,\n"
+        "    cache: Option<Cache>,\n"
+        "    pub metrics: [100]f64\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    ASTNode* struct_decl = decls->nodes[0];
+    ASTNodeList* fields = struct_decl->data.struct_decl.fields;
+    
+    // Verify visibility is independent of type complexity
+    assert(ast_node_list_get(fields, 0)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // connections
+    assert(ast_node_list_get(fields, 1)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // credentials
+    assert(ast_node_list_get(fields, 2)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // cache (default)
+    assert(ast_node_list_get(fields, 3)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // metrics
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Visibility with complex types parsed correctly\n");
+}
+
+// Test 6: Nested structs with field visibility
+void test_nested_structs_visibility(void) {
+    printf("Testing nested structs with field visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Address {\n"
+        "    pub street: string,\n"
+        "    pub city: string,\n"
+        "    priv apartment_number: Option<string>\n"
+        "}\n"
+        "\n"
+        "pub struct Person {\n"
+        "    pub name: string,\n"
+        "    priv ssn: string,\n"
+        "    pub address: Address\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    assert(ast_node_list_size(decls) == 2);
+    
+    // Check Address struct
+    ASTNode* address_struct = decls->nodes[0];
+    ASTNodeList* address_fields = address_struct->data.struct_decl.fields;
+    assert(ast_node_list_get(address_fields, 0)->data.struct_field.visibility == VISIBILITY_PUBLIC);
+    assert(ast_node_list_get(address_fields, 1)->data.struct_field.visibility == VISIBILITY_PUBLIC);
+    assert(ast_node_list_get(address_fields, 2)->data.struct_field.visibility == VISIBILITY_PRIVATE);
+    
+    // Check Person struct
+    ASTNode* person_struct = decls->nodes[1];
+    ASTNodeList* person_fields = person_struct->data.struct_decl.fields;
+    assert(ast_node_list_get(person_fields, 0)->data.struct_field.visibility == VISIBILITY_PUBLIC);
+    assert(ast_node_list_get(person_fields, 1)->data.struct_field.visibility == VISIBILITY_PRIVATE);
+    assert(ast_node_list_get(person_fields, 2)->data.struct_field.visibility == VISIBILITY_PUBLIC);
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Nested structs with field visibility parsed correctly\n");
+}
+
+// Test 7: Generic structs with field visibility
+void test_generic_struct_field_visibility(void) {
+    printf("Testing generic struct field visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Container<T> {\n"
+        "    pub value: T,\n"
+        "    priv metadata: string,\n"
+        "    capacity: i32\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    ASTNode* struct_decl = decls->nodes[0];
+    
+    // Verify generic struct has type parameters
+    assert(struct_decl->data.struct_decl.type_params != NULL);
+    assert(ast_node_list_size(struct_decl->data.struct_decl.type_params) == 1);
+    
+    // Check field visibility
+    ASTNodeList* fields = struct_decl->data.struct_decl.fields;
+    assert(ast_node_list_get(fields, 0)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // value
+    assert(ast_node_list_get(fields, 1)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // metadata
+    assert(ast_node_list_get(fields, 2)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // capacity
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Generic struct field visibility parsed correctly\n");
+}
+
+// Test 8: Empty struct (with none)
+void test_empty_struct_no_fields(void) {
+    printf("Testing empty struct with no fields ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Empty { none }\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    ASTNode* struct_decl = decls->nodes[0];
+    
+    // Empty struct should have no fields
+    assert(struct_decl->data.struct_decl.fields == NULL);
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Empty struct parsed correctly\n");
+}
+
+// Test 9: Struct with method implementations (fields only)
+void test_struct_for_method_context(void) {
+    printf("Testing struct fields in method context ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Rectangle {\n"
+        "    pub width: f64,\n"
+        "    pub height: f64,\n"
+        "    priv id: i32\n"
+        "}\n"
+        "\n"
+        "impl Rectangle {\n"
+        "    pub fn area(self) -> f64 {\n"
+        "        return self.width * self.height;\n"
+        "    }\n"
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    assert(program != NULL);
+    
+    ASTNodeList* decls = program->data.program.declarations;
+    
+    // Check struct fields visibility
+    ASTNode* struct_decl = decls->nodes[0];
+    ASTNodeList* fields = struct_decl->data.struct_decl.fields;
+    assert(ast_node_list_get(fields, 0)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // width
+    assert(ast_node_list_get(fields, 1)->data.struct_field.visibility == VISIBILITY_PUBLIC);   // height
+    assert(ast_node_list_get(fields, 2)->data.struct_field.visibility == VISIBILITY_PRIVATE);  // id
+    
+    ast_free_node(program);
+    parser_destroy(parser);
+    printf("  ✓ Struct fields in method context parsed correctly\n");
+}
+
+// Test 10: Multiple visibility modifiers (error case)
+void test_invalid_multiple_visibility(void) {
+    printf("Testing invalid multiple visibility modifiers ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "pub struct Invalid {\n"
+        "    pub priv x: i32\n"  // This should be an error
+        "}\n";
+    
+    Parser* parser = create_parser(source);
+    assert(parser != NULL);
+    
+    ASTNode* program = parse_program(parser);
+    // Parser might handle this differently - either error or take first/last modifier
+    
+    if (program) {
+        ast_free_node(program);
+    }
+    parser_destroy(parser);
+    printf("  ✓ Invalid multiple visibility handled\n");
+}
+
+int main(void) {
+    printf("=== Comprehensive Struct Field Visibility Test Suite ===\n\n");
+    
+    test_public_field();
+    test_private_field();
+    test_mixed_visibility_fields();
+    test_default_visibility();
+    test_visibility_with_complex_types();
+    test_nested_structs_visibility();
+    test_generic_struct_field_visibility();
+    test_empty_struct_no_fields();
+    test_struct_for_method_context();
+    test_invalid_multiple_visibility();
+    
+    printf("\n✅ All struct field visibility parser tests completed!\n");
+    return 0;
+}

--- a/tests/semantic/test_struct_field_visibility_semantic.c
+++ b/tests/semantic/test_struct_field_visibility_semantic.c
@@ -1,0 +1,340 @@
+/**
+ * Semantic analysis tests for struct field visibility enforcement
+ * Tests whether private fields are properly protected from external access
+ * 
+ * Copyright (c) 2024 Asthra Project
+ * Licensed under the terms specified in LICENSE
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "../../src/parser/lexer.h"
+#include "../../src/parser/parser.h"
+#include "../../src/parser/ast.h"
+#include "../../src/analysis/semantic_analyzer.h"
+#include "../../src/analysis/semantic_errors.h"
+
+// Helper function to run semantic analysis
+static SemanticAnalyzer* analyze_source(const char* source) {
+    Lexer* lexer = lexer_create(source, strlen(source), "<test>");
+    if (!lexer) return NULL;
+    
+    Parser* parser = parser_create(lexer);
+    if (!parser) {
+        lexer_destroy(lexer);
+        return NULL;
+    }
+    
+    ASTNode* program = parse_program(parser);
+    parser_destroy(parser);
+    
+    if (!program) return NULL;
+    
+    SemanticAnalyzer* analyzer = semantic_analyzer_create();
+    if (!analyzer) {
+        ast_free_node(program);
+        return NULL;
+    }
+    
+    semantic_analyze_program(analyzer, program);
+    ast_free_node(program);
+    
+    return analyzer;
+}
+
+// Test 1: Access public field from same package
+void test_access_public_field_same_package(void) {
+    printf("Testing access to public field from same package ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct Point {\n"
+        "    pub x: i32,\n"
+        "    pub y: i32\n"
+        "}\n"
+        "\n"
+        "pub fn test_public_access(none) -> void {\n"
+        "    let p: Point = Point { x: 10, y: 20 };\n"
+        "    let x_val: i32 = p.x;  // Should be allowed\n"
+        "    let y_val: i32 = p.y;  // Should be allowed\n"
+        "    return ();\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    // Should have no errors
+    assert(analyzer->error_count == 0);
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Public field access allowed in same package\n");
+}
+
+// Test 2: Access private field from same package
+void test_access_private_field_same_package(void) {
+    printf("Testing access to private field from same package ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct BankAccount {\n"
+        "    pub account_number: string,\n"
+        "    priv balance: f64,\n"
+        "    priv pin: i32\n"
+        "}\n"
+        "\n"
+        "pub fn test_private_access(none) -> void {\n"
+        "    let account: BankAccount = BankAccount {\n"
+        "        account_number: \"123456\",\n"
+        "        balance: 1000.0,\n"
+        "        pin: 1234\n"
+        "    };\n"
+        "    let num: string = account.account_number;  // OK - public\n"
+        "    let bal: f64 = account.balance;  // Should be error - private\n"
+        "    let p: i32 = account.pin;        // Should be error - private\n"
+        "    return ();\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    // TODO: Currently the semantic analyzer doesn't enforce field visibility
+    // When implemented, this test should show errors for accessing private fields
+    // For now, we document the current behavior
+    
+    printf("    Current behavior: Private fields not enforced (TODO in semantic_structs_visibility.c)\n");
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Test documents current behavior\n");
+}
+
+// Test 3: Mixed visibility in struct literal
+void test_struct_literal_with_visibility(void) {
+    printf("Testing struct literal initialization with mixed visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct User {\n"
+        "    pub id: i32,\n"
+        "    pub name: string,\n"
+        "    priv password_hash: string\n"
+        "}\n"
+        "\n"
+        "pub fn create_user(none) -> User {\n"
+        "    // Should be able to initialize private fields within same module\n"
+        "    return User {\n"
+        "        id: 1,\n"
+        "        name: \"Alice\",\n"
+        "        password_hash: \"hashed123\"\n"
+        "    };\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    // Struct literal initialization should work regardless of field visibility
+    // within the same module
+    assert(analyzer->error_count == 0);
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Struct literal initialization allowed for all fields\n");
+}
+
+// Test 4: Default visibility enforcement
+void test_default_visibility_enforcement(void) {
+    printf("Testing default (private) visibility enforcement ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct Config {\n"
+        "    timeout: i32,      // default private\n"
+        "    pub retries: i32,\n"
+        "    verbose: bool      // default private\n"
+        "}\n"
+        "\n"
+        "pub fn test_defaults(none) -> void {\n"
+        "    let cfg: Config = Config {\n"
+        "        timeout: 30,\n"
+        "        retries: 3,\n"
+        "        verbose: true\n"
+        "    };\n"
+        "    let t: i32 = cfg.timeout;   // Should be error - private by default\n"
+        "    let r: i32 = cfg.retries;   // OK - public\n"
+        "    let v: bool = cfg.verbose;  // Should be error - private by default\n"
+        "    return ();\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    // Document current behavior
+    printf("    Current behavior: Default private visibility not enforced\n");
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Test documents default visibility behavior\n");
+}
+
+// Test 5: Method access to private fields
+void test_method_access_to_private_fields(void) {
+    printf("Testing method access to private fields ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct Rectangle {\n"
+        "    pub width: f64,\n"
+        "    pub height: f64,\n"
+        "    priv area_cache: f64\n"
+        "}\n"
+        "\n"
+        "impl Rectangle {\n"
+        "    pub fn calculate_area(self) -> f64 {\n"
+        "        // Methods should access private fields of their own struct\n"
+        "        if self.area_cache > 0.0 {\n"
+        "            return self.area_cache;\n"
+        "        }\n"
+        "        return self.width * self.height;\n"
+        "    }\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    // Methods should be able to access private fields of their struct
+    assert(analyzer->error_count == 0);
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Methods can access private fields of their struct\n");
+}
+
+// Test 6: Cross-struct private field access
+void test_cross_struct_private_access(void) {
+    printf("Testing cross-struct private field access ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct A {\n"
+        "    pub public_a: i32,\n"
+        "    priv private_a: i32\n"
+        "}\n"
+        "\n"
+        "pub struct B {\n"
+        "    pub public_b: i32,\n"
+        "    priv private_b: i32\n"
+        "}\n"
+        "\n"
+        "impl A {\n"
+        "    pub fn access_b(self, b: B) -> i32 {\n"
+        "        let pub_ok: i32 = b.public_b;   // OK - public\n"
+        "        let priv_err: i32 = b.private_b; // Should be error\n"
+        "        return pub_ok + priv_err;\n"
+        "    }\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    // Document current behavior for cross-struct access
+    printf("    Current behavior: Cross-struct private access not enforced\n");
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Test documents cross-struct visibility behavior\n");
+}
+
+// Test 7: Nested field access with visibility
+void test_nested_field_visibility(void) {
+    printf("Testing nested struct field visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct Inner {\n"
+        "    pub visible: i32,\n"
+        "    priv hidden: i32\n"
+        "}\n"
+        "\n"
+        "pub struct Outer {\n"
+        "    pub inner: Inner,\n"
+        "    priv secret: Inner\n"
+        "}\n"
+        "\n"
+        "pub fn test_nested(none) -> void {\n"
+        "    let o: Outer = Outer {\n"
+        "        inner: Inner { visible: 1, hidden: 2 },\n"
+        "        secret: Inner { visible: 3, hidden: 4 }\n"
+        "    };\n"
+        "    \n"
+        "    // These should be checked:\n"
+        "    let v1: i32 = o.inner.visible;   // OK - both fields public\n"
+        "    let h1: i32 = o.inner.hidden;    // Error - hidden is private\n"
+        "    let s: Inner = o.secret;         // Error - secret is private\n"
+        "    return ();\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    printf("    Current behavior: Nested field visibility not enforced\n");
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Test documents nested visibility behavior\n");
+}
+
+// Test 8: Generic struct field visibility
+void test_generic_struct_visibility(void) {
+    printf("Testing generic struct field visibility ...\n");
+    
+    const char* source = 
+        "package test;\n"
+        "\n"
+        "pub struct Container<T> {\n"
+        "    pub value: T,\n"
+        "    priv metadata: string\n"
+        "}\n"
+        "\n"
+        "pub fn test_generic(none) -> void {\n"
+        "    let c: Container<i32> = Container<i32> {\n"
+        "        value: 42,\n"
+        "        metadata: \"secret\"\n"
+        "    };\n"
+        "    \n"
+        "    let v: i32 = c.value;        // OK - public\n"
+        "    let m: string = c.metadata;  // Should be error - private\n"
+        "    return ();\n"
+        "}\n";
+    
+    SemanticAnalyzer* analyzer = analyze_source(source);
+    assert(analyzer != NULL);
+    
+    printf("    Current behavior: Generic struct field visibility not enforced\n");
+    
+    semantic_analyzer_destroy(analyzer);
+    printf("  ✓ Test documents generic struct visibility behavior\n");
+}
+
+int main(void) {
+    printf("=== Struct Field Visibility Semantic Tests ===\n\n");
+    
+    test_access_public_field_same_package();
+    test_access_private_field_same_package();
+    test_struct_literal_with_visibility();
+    test_default_visibility_enforcement();
+    test_method_access_to_private_fields();
+    test_cross_struct_private_access();
+    test_nested_field_visibility();
+    test_generic_struct_visibility();
+    
+    printf("\n📝 Summary: Field visibility is parsed correctly but not enforced\n");
+    printf("   - Parser extracts visibility modifiers correctly\n");
+    printf("   - Semantic analyzer has TODO for enforcement\n");
+    printf("   - All field access is currently allowed\n");
+    printf("\n✅ All semantic tests completed!\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Investigated struct field visibility modifiers (`pub`/`priv`) as defined in grammar.txt line 46
- Found that visibility is correctly parsed but NOT enforced by semantic analyzer
- Created comprehensive tests documenting current behavior

## Test plan
- [x] Created 10 parser tests - all pass (visibility correctly extracted)
- [x] Created 8 semantic tests - document that enforcement is missing
- [x] Verified with full test suite run - all tests pass
- [x] Created detailed analysis in struct-field-visibility-analysis.md

## Key Findings
1. **Parser**: ✅ Fully implemented - correctly extracts visibility modifiers
2. **Semantic**: ❌ NOT enforced - has TODO comment in `semantic_structs_visibility.c`
3. **Impact**: All struct fields are effectively public regardless of modifier

## Documentation
- Updated `grammar-implementation-gaps.md` marking as "PARTIALLY IMPLEMENTED"
- Created comprehensive analysis document with implementation recommendations

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>