### PR TITLE
refactor(docs): reduce CLAUDE.md size by 43% through content extraction

### DIFF
--- a/docs/architecture/expression-oriented-design.md
+++ b/docs/architecture/expression-oriented-design.md
@@ -4,6 +4,33 @@
 
 This document captures the key architectural insights discovered during the development and testing of Asthra's code generation system, specifically relating to the language's expression-oriented design and its impact on compiler implementation.
 
+## Test Pattern Examples
+
+### Expression-Oriented Test Patterns
+
+When writing tests for Asthra, follow expression-oriented patterns:
+
+```c
+// ✅ CORRECT: Expression-oriented patterns
+const char* source = 
+    "package test;\n"
+    "pub fn main(none) -> void {\n"
+    "    let result = if condition { 42 } else { 0 };\n"
+    "    return ();\n"  // Explicit return required
+    "}\n";
+
+// ❌ INCORRECT: Statement-oriented patterns  
+const char* bad_source = 
+    "if (condition) { action(); } else { other(); }"  // Missing package, returns, types
+```
+
+### Key Testing Principles
+
+1. **Always include package declaration** - Asthra requires explicit package context
+2. **Explicit returns** - Even void functions must use `return ();`
+3. **Expression values** - Control flow constructs return values
+4. **Type consistency** - All branches must return compatible types
+
 ## Expression-Oriented Language Design
 
 ### Core Principle

--- a/docs/contributor/guides/bdd-testing-guide.md
+++ b/docs/contributor/guides/bdd-testing-guide.md
@@ -304,6 +304,32 @@ cmake --build build --target bdd_acceptance
 
 # Run specific scenarios
 ./build/bdd/bin/test_parser_expressions -s "Binary expression"
+
+# Running specific BDD feature files
+./build/bdd/bin/bdd_unit_compiler_basic        # Run compiler basic functionality tests
+./build/bdd/bin/bdd_unit_function_calls        # Run function call tests
+./build/bdd/bin/bdd_unit_if_conditions         # Run if condition tests
+./build/bdd/bin/bdd_unit_bitwise_operators     # Run bitwise operator tests
+./build/bdd/bin/bdd_integration_cli            # Run CLI integration tests
+./build/bdd/bin/bdd_integration_ffi_integration # Run FFI integration tests
+```
+
+### BDD Test Output Interpretation
+
+- ✓ = Test passed
+- ✗ = Test failed
+- Each scenario shows step-by-step execution with assertions
+- Summary shows: Passed/Failed/Total counts at the end
+
+Example output:
+```
+Feature: Basic Compiler Functionality
+  Scenario: Compile and run a simple Hello World program
+    Given the Asthra compiler is available
+      ✓ exists should be true
+    When I compile the file
+    Then the compilation should succeed
+      ✓ compilation_exit_code should equal 0
 ```
 
 ### Generate Test Reports
@@ -322,11 +348,11 @@ open build/bdd/reports/bdd-report.html
 
 ```
 bdd/
-├── features/              # Gherkin feature files
+├── features/              # Gherkin feature files (*.feature)
 │   ├── compiler/         # Compiler features
 │   ├── parser/           # Parser features
 │   └── semantic/         # Semantic analysis features
-├── steps/                # Step definitions
+├── steps/                # Step definitions (C implementations)
 │   ├── unit/            # Unit test steps
 │   │   ├── parser/      # Parser unit tests
 │   │   ├── semantic/    # Semantic unit tests
@@ -336,7 +362,11 @@ bdd/
 │   ├── scenario/        # Scenario test steps
 │   └── feature/         # Feature test steps
 ├── support/             # Shared test support code
-└── fixtures/            # Test data and examples
+├── fixtures/            # Test data and examples
+└── CMakeLists.txt       # BDD test configuration
+
+Test executables are built to: build/bdd/bin/bdd_*
+Scenarios marked with @wip are skipped during test runs.
 ```
 
 ### Test Categories
@@ -370,6 +400,20 @@ bdd/
   - Example: `parser_expressions.feature`
 - Test functions: Descriptive scenario names
   - Example: "Parse binary arithmetic expressions"
+
+### Test Artifacts and Debugging Environment
+
+To preserve test artifacts for debugging:
+```bash
+export BDD_KEEP_ARTIFACTS=1  # Preserve test artifacts in bdd-temp/
+```
+
+Clean test execution pattern:
+```c
+// Always call cleanup before reporting
+common_cleanup();
+return bdd_report();
+```
 
 ## Debugging BDD Tests
 

--- a/docs/contributor/guides/gitignore-compliance.md
+++ b/docs/contributor/guides/gitignore-compliance.md
@@ -1,0 +1,171 @@
+# Gitignore Compliance Guide
+
+This guide explains how to work with Asthra's `.gitignore` patterns to avoid accidentally creating files that won't be tracked by Git or that will be lost during cleanup operations.
+
+## Critical Warning
+
+**Files matching `.gitignore` patterns will NOT be committed to Git and WILL BE LOST when running `git clean -fdx`**
+
+## Problematic Patterns for Source Files
+
+### Debug Files
+**NEVER use these patterns for permanent source files:**
+- `debug_*.c`, `debug_*.h` - Debug prefix pattern
+- `*_debug.c`, `*_debug.h` - Debug suffix pattern
+- `debug_*.*` - Any debug-prefixed file
+
+These patterns are reserved for temporary debugging files that should not be committed.
+
+### Test Executables
+**NEVER name source files with these patterns:**
+- `*_test` (without extension) - This matches test executables
+- Always use `.c` or `.h` extensions for source files
+
+### Documentation
+**Avoid these patterns for permanent documentation:**
+- `*_error_analysis.md` - Reserved for temporary error analysis
+- `*_migration_summary.md` - Reserved for migration notes
+- `TODO.local.md` - Reserved for personal notes
+- `local-notes.txt` - Reserved for local development notes
+
+## Safe Patterns for Source Files
+
+### Test Source Files
+✅ **CORRECT patterns:**
+- `test_*.c`, `test_*.h` - Test files with test_ prefix
+- `*_test_*.c`, `*_test_*.h` - Files with _test_ in the middle
+- `test_semantic.c` - Good test file name
+- `parser_test_utils.c` - Good utility file name
+
+❌ **INCORRECT patterns:**
+- `semantic_test` - Missing extension (will be ignored)
+- `debug_test.c` - Starts with debug_ (will be ignored)
+- `test_debug.c` - Contains debug (will be ignored)
+
+### Regular Source Files
+✅ **Always safe:**
+- Standard names: `parser.c`, `semantic.h`, `codegen.c`
+- Module names: `ast_types.h`, `symbol_table.c`
+- Implementation files: `parser_impl.c`, `semantic_analysis.h`
+
+## Using Gitignore Patterns for Temporary Files
+
+### Recommended Temporary File Patterns
+
+These patterns are ENCOURAGED for temporary work:
+
+```bash
+# Debugging files
+debug_parser_issue.c      # Temporary debugging code
+parser_debug.c           # Debug version of parser
+debug_analysis.md        # Debug notes
+
+# Analysis documents  
+semantic_error_analysis.md    # Error investigation
+parser_migration_summary.md   # Migration notes
+
+# Test outputs
+parser_test_output.txt       # Test results
+semantic_test_output.log     # Test logs
+
+# Personal notes
+TODO.local.md               # Personal todo list
+local-notes.txt             # Local development notes
+```
+
+### Benefits of Using Temporary Patterns
+
+1. **No accidental commits** - Files are automatically ignored
+2. **Easy cleanup** - `git clean -fdx` removes all temporary files
+3. **Clear separation** - Temporary vs permanent files are obvious
+4. **Team-friendly** - Personal files don't clutter the repository
+
+## Verification Commands
+
+### Check if a File Will Be Ignored
+
+Before creating a file, verify it won't be ignored:
+
+```bash
+# Check if a file would be ignored
+git check-ignore -v proposed_filename.c
+
+# No output = file will be tracked
+# Output shows which .gitignore rule matches
+```
+
+### List All Ignored Files
+
+```bash
+# Show all ignored files in the repository
+git status --ignored
+
+# Show ignored files in a specific directory
+git status --ignored src/
+```
+
+### Clean Temporary Files
+
+```bash
+# Preview what will be deleted
+git clean -fdx --dry-run
+
+# Remove all untracked and ignored files
+git clean -fdx
+
+# Remove only ignored files (keep untracked)
+git clean -fdX
+```
+
+## Best Practices
+
+1. **Always add extensions** to source files (`.c`, `.h`, `.md`)
+2. **Check before creating** - Use `git check-ignore -v` for new filenames
+3. **Use temporary patterns** for debugging and analysis work
+4. **Document exceptions** if you must use a special pattern
+5. **Review `.gitignore`** periodically to understand current patterns
+
+## Common Mistakes to Avoid
+
+### Mistake 1: Debug Prefixed Source Files
+```bash
+# ❌ WRONG - Will be ignored
+touch debug_parser.c
+git add debug_parser.c  # Won't work!
+
+# ✅ CORRECT - Will be tracked
+touch parser_debug_info.c
+git add parser_debug_info.c  # Works!
+```
+
+### Mistake 2: Missing Extensions
+```bash
+# ❌ WRONG - Looks like executable
+touch parser_test
+git add parser_test  # Won't work!
+
+# ✅ CORRECT - Clear source file
+touch test_parser.c
+git add test_parser.c  # Works!
+```
+
+### Mistake 3: Using Reserved Patterns
+```bash
+# ❌ WRONG - Reserved for temporary analysis
+touch parser_error_analysis.md
+git add parser_error_analysis.md  # Won't work!
+
+# ✅ CORRECT - Different naming
+touch parser_error_investigation.md
+git add parser_error_investigation.md  # Works!
+```
+
+## Summary
+
+- **Know the patterns** - Understand what `.gitignore` will ignore
+- **Use safe names** - Follow established naming conventions
+- **Leverage temporary patterns** - Use ignored patterns for temporary work
+- **Verify before creating** - Check if files will be tracked
+- **Clean regularly** - Use `git clean` to remove temporary files
+
+Following these guidelines ensures your important work is never lost and your repository stays clean and organized.

--- a/docs/contributor/reference/commands-quick-reference.md
+++ b/docs/contributor/reference/commands-quick-reference.md
@@ -1,0 +1,270 @@
+# Asthra Commands Quick Reference
+
+This is a comprehensive reference for all commands used in Asthra development. For the most commonly used commands, see the "Essential Commands" section in CLAUDE.md.
+
+## Build Commands
+
+### Basic Build Operations
+```bash
+cmake -B build && cmake --build build          # Build compiler with optimizations (default)
+cmake --build build --target clean             # Clean all build artifacts
+cmake -B build -DCMAKE_BUILD_TYPE=Debug && cmake --build build    # Build with debug symbols
+cmake -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build  # Build optimized release
+```
+
+### Platform-Specific Builds
+```bash
+# macOS Universal Binary
+cmake -B build -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+
+# Linux with specific compiler
+CC=gcc-11 CXX=g++-11 cmake -B build
+
+# Windows with MSVC
+cmake -B build -G "Visual Studio 17 2022"
+```
+
+## Testing Commands
+
+### Core Testing
+```bash
+ctest --test-dir build                          # Run all tests
+ctest --test-dir build --verbose               # Comprehensive test suite with reporting
+cmake --build build --target build-tests       # Build all test executables (required after clean)
+```
+
+### Component-Specific Testing
+```bash
+# Run tests for specific component (component must exist under tests/)
+ctest --test-dir build -L <component-name>     # Example: ctest -L semantic, ctest -L parser
+
+# Sub-category testing (available for some components)
+ctest --test-dir build -R "codegen.*function"  # Run only function call tests
+ctest --test-dir build -R "codegen.*control"   # Run only control flow tests
+ctest --test-dir build -R "parser.*expression" # Run only expression parser tests
+ctest --test-dir build -R "parser.*statement"  # Run only statement parser tests
+ctest --test-dir build -R "semantic.*types"    # Run only type checking tests
+ctest --test-dir build -R "semantic.*symbols"  # Run only symbol resolution tests
+```
+
+### Parallel Testing
+```bash
+ctest --test-dir build -j8                     # Run tests in parallel with 8 threads
+ctest --test-dir build -L <component> -j8      # Component tests in parallel
+ctest --test-dir build --parallel 16           # Use 16 parallel jobs
+```
+
+### Test Output and Reporting
+```bash
+ctest --test-dir build --output-on-failure     # View test failures with output
+ctest --test-dir build --verbose               # Verbose output for all tests
+ctest --test-dir build --rerun-failed          # Re-run only failed tests
+ctest --test-dir build --output-junit report.xml # Generate JUnit XML report
+```
+
+## BDD Testing Commands
+
+### Build and Run BDD Tests
+```bash
+cmake -B build -DBUILD_BDD_TESTS=ON            # Enable BDD tests in build configuration
+cmake --build build --target bdd_tests         # Build all BDD test executables
+cmake --build build --target run_bdd_tests     # Run full BDD test suite
+cmake --build build --target bdd_unit          # Run C BDD unit tests only
+cmake --build build --target bdd_integration   # Run BDD integration tests only
+cmake --build build --target bdd_cucumber      # Run Cucumber features (if available)
+cmake --build build --target bdd-report        # Generate BDD test report (JUnit format)
+ctest --test-dir build -L bdd                  # Run BDD tests using CTest
+```
+
+### Running Individual BDD Tests
+```bash
+./build/bdd/bin/bdd_unit_compiler_basic        # Run compiler basic functionality tests
+./build/bdd/bin/bdd_unit_function_calls        # Run function call tests
+./build/bdd/bin/bdd_unit_if_conditions         # Run if condition tests
+./build/bdd/bin/bdd_unit_bitwise_operators     # Run bitwise operator tests
+./build/bdd/bin/bdd_integration_cli            # Run CLI integration tests
+./build/bdd/bin/bdd_integration_ffi_integration # Run FFI integration tests
+```
+
+### BDD Environment Variables
+```bash
+export BDD_DEBUG=1                             # Enable debug output for BDD tests
+export BDD_KEEP_ARTIFACTS=1                    # Preserve test artifacts in bdd-temp/
+export BDD_TIMEOUT=60                          # Set test timeout in seconds
+```
+
+## Coverage and Analysis
+
+### Code Coverage
+```bash
+cmake --build build --target coverage          # Generate coverage reports
+cmake --build build --target coverage-html     # HTML coverage reports
+cmake --build build --target coverage-summary  # Summary coverage report
+
+# View coverage
+open build/coverage/index.html                 # macOS
+xdg-open build/coverage/index.html            # Linux
+```
+
+### Static Analysis
+```bash
+cmake --build build --target analyze           # Run static analysis with Clang
+cmake --build build --target cppcheck         # Run cppcheck (if available)
+cmake --build build --target pvs-studio       # Run PVS-Studio (if licensed)
+```
+
+### Code Formatting
+```bash
+cmake --build build --target format            # Format all source files
+cmake --build build --target format-check      # Check formatting without modifying
+```
+
+## Performance and Benchmarking
+
+```bash
+cmake --build build --target benchmark         # Run optimized benchmarks
+cmake --build build --target perf-test        # Run performance regression tests
+cmake --build build --target profile          # Build with profiling enabled
+```
+
+## Sanitizer Builds
+
+```bash
+# AddressSanitizer (memory errors, leaks)
+cmake -B build -DSANITIZER=Address
+cmake --build build && ./build/asthra_test
+
+# ThreadSanitizer (data races)
+cmake -B build -DSANITIZER=Thread
+cmake --build build && ./build/asthra_test
+
+# UndefinedBehaviorSanitizer
+cmake -B build -DSANITIZER=Undefined
+cmake --build build && ./build/asthra_test
+
+# MemorySanitizer (uninitialized memory)
+cmake -B build -DSANITIZER=Memory
+cmake --build build && ./build/asthra_test
+```
+
+## Build Tool Commands (Ampu)
+
+```bash
+cd ampu && cargo build                         # Build the Ampu build tool
+cd ampu && cargo test                          # Run Ampu unit tests
+./ampu/run_e2e_tests.sh                       # End-to-end tests
+cargo test --test language_tests              # Language feature tests
+cargo run -- build                            # Build project using Ampu
+cargo run -- test                             # Run tests using Ampu
+cargo run -- clean                            # Clean using Ampu
+```
+
+## Documentation Generation
+
+```bash
+cmake --build build --target docs              # Generate documentation
+cmake --build build --target doxygen          # Generate Doxygen docs
+cmake --build build --target man              # Generate man pages
+```
+
+## Installation Commands
+
+```bash
+cmake --build build --target install          # Install to system
+cmake --install build --prefix ~/asthra       # Install to custom location
+cmake --build build --target package          # Create distribution package
+```
+
+## Development Utilities
+
+```bash
+# Generate compile_commands.json for IDE support
+cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+# Build with verbose output
+cmake --build build --verbose
+
+# Clean and rebuild everything
+cmake --build build --target clean && cmake --build build
+
+# Check dependencies
+cmake --build build --target deps-check
+
+# Update git submodules
+git submodule update --init --recursive
+```
+
+## Debugging Commands
+
+```bash
+# Build with debug symbols
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+
+# Run with gdb
+gdb ./build/asthra
+
+# Run with lldb
+lldb ./build/asthra
+
+# Generate core dumps
+ulimit -c unlimited
+./build/asthra_test
+
+# Analyze core dump
+gdb ./build/asthra core
+```
+
+## CI/CD Commands
+
+```bash
+# Run CI locally
+act -j build                                  # Using GitHub Actions locally
+
+# Pre-commit checks
+./scripts/pre-commit.sh                       # Run all pre-commit checks
+
+# Release build
+./scripts/release.sh --version 1.0.0         # Create release build
+```
+
+## Tips and Tricks
+
+### Incremental Builds
+Always prefer incremental builds over clean builds:
+```bash
+cmake --build build                           # Incremental build (fast)
+# vs
+cmake --build build --target clean && cmake --build build  # Full rebuild (slow)
+```
+
+### Parallel Builds
+Use parallel jobs to speed up compilation:
+```bash
+cmake --build build -j$(nproc)               # Linux: use all cores
+cmake --build build -j$(sysctl -n hw.ncpu)   # macOS: use all cores
+cmake --build build -j8                      # Manual: use 8 cores
+```
+
+### Build-Test Workflow
+The recommended workflow for making changes:
+```bash
+# 1. Make your changes
+# 2. Build incrementally
+cmake --build build -j8
+
+# 3. Build test executables if needed
+cmake --build build --target build-tests
+
+# 4. Run relevant tests
+ctest --test-dir build -L semantic -j8       # Fast component testing
+
+# 5. Run full test suite before committing
+ctest --test-dir build
+```
+
+## See Also
+
+- `docs/contributor/guides/test-build-strategy.md` - Critical test building strategies
+- `docs/contributor/guides/bdd-testing-guide.md` - Comprehensive BDD testing guide
+- `docs/contributor/guides/development-guide.md` - General development guidelines
+- `CLAUDE.md` - Essential commands for AI-assisted development

--- a/scripts/check-claude-md-size.sh
+++ b/scripts/check-claude-md-size.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# check-claude-md-size.sh
+# Script to check CLAUDE.md file size and warn if it exceeds target
+
+# Configuration
+TARGET_LINES=250
+WARNING_LINES=240
+CLAUDE_MD="CLAUDE.md"
+
+# ANSI color codes
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Check if CLAUDE.md exists
+if [ ! -f "$CLAUDE_MD" ]; then
+    echo -e "${RED}Error: $CLAUDE_MD not found in current directory${NC}"
+    exit 1
+fi
+
+# Get current line count
+CURRENT_LINES=$(wc -l < "$CLAUDE_MD")
+
+# Function to suggest sections to extract
+suggest_extraction() {
+    echo -e "\n${YELLOW}Suggested sections to extract:${NC}"
+    
+    # Count lines in major sections
+    echo "Section line counts:"
+    
+    # Find sections with code blocks (often good candidates for extraction)
+    echo -e "\n${YELLOW}Sections with code examples (good extraction candidates):${NC}"
+    grep -n "^###.*" "$CLAUDE_MD" | while read -r line; do
+        linenum=$(echo "$line" | cut -d: -f1)
+        section=$(echo "$line" | cut -d: -f2-)
+        
+        # Check if section has code blocks
+        next_section=$(grep -n "^###" "$CLAUDE_MD" | grep -A1 "^$linenum:" | tail -1 | cut -d: -f1)
+        if [ -z "$next_section" ]; then
+            next_section=$(wc -l < "$CLAUDE_MD")
+        fi
+        
+        code_blocks=$(sed -n "${linenum},${next_section}p" "$CLAUDE_MD" | grep -c '```')
+        if [ "$code_blocks" -gt 0 ]; then
+            lines=$((next_section - linenum))
+            echo "  - $section (lines $linenum-$next_section, ~$lines lines, $((code_blocks/2)) code blocks)"
+        fi
+    done
+    
+    echo -e "\n${YELLOW}Consider moving detailed content to:${NC}"
+    echo "  - docs/contributor/reference/ for reference material"
+    echo "  - docs/contributor/guides/ for detailed guides"
+    echo "  - docs/architecture/ for design documentation"
+    echo "  - docs/spec/ for language specifications"
+}
+
+# Check file size
+if [ "$CURRENT_LINES" -gt "$TARGET_LINES" ]; then
+    echo -e "${RED}❌ CLAUDE.md exceeds target size!${NC}"
+    echo "   Current: $CURRENT_LINES lines"
+    echo "   Target:  $TARGET_LINES lines"
+    echo "   Excess:  $((CURRENT_LINES - TARGET_LINES)) lines"
+    
+    suggest_extraction
+    
+    exit 1
+elif [ "$CURRENT_LINES" -gt "$WARNING_LINES" ]; then
+    echo -e "${YELLOW}⚠️  CLAUDE.md approaching target size${NC}"
+    echo "   Current: $CURRENT_LINES lines"
+    echo "   Warning: $WARNING_LINES lines"
+    echo "   Target:  $TARGET_LINES lines"
+    echo "   Remaining: $((TARGET_LINES - CURRENT_LINES)) lines"
+    
+    echo -e "\n${YELLOW}Consider extracting content before reaching the limit.${NC}"
+    
+    exit 0
+else
+    echo -e "${GREEN}✅ CLAUDE.md size is good${NC}"
+    echo "   Current: $CURRENT_LINES lines"
+    echo "   Target:  $TARGET_LINES lines"
+    echo "   Buffer:  $((TARGET_LINES - CURRENT_LINES)) lines remaining"
+    
+    exit 0
+fi

--- a/scripts/pre-commit-claude-check.example
+++ b/scripts/pre-commit-claude-check.example
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Example pre-commit hook to check CLAUDE.md size
+# To use: copy this file to .git/hooks/pre-commit and make it executable
+
+# Check if CLAUDE.md is being committed
+if git diff --cached --name-only | grep -q "^CLAUDE.md$"; then
+    echo "Checking CLAUDE.md size..."
+    
+    # Run the size check script
+    ./scripts/check-claude-md-size.sh
+    
+    # Exit with the script's exit code
+    exit $?
+fi
+
+# If CLAUDE.md is not being modified, continue
+exit 0


### PR DESCRIPTION
## Summary
- Reduced CLAUDE.md from 377 to 215 lines (43% reduction, 162 lines saved)
- Extracted detailed content to appropriate documentation files
- Created tooling to monitor and maintain file size

## Changes Made

### Content Extraction
- **BDD testing details** → `docs/contributor/guides/bdd-testing-guide.md` (saved 33 lines)
- **Command reference** → `docs/contributor/reference/commands-quick-reference.md` (saved 35 lines)
- **Gitignore guide** → `docs/contributor/guides/gitignore-compliance.md` (saved 18 lines)
- **Expression examples** → `docs/architecture/expression-oriented-design.md` (saved 14 lines)

### Structural Improvements
- Converted Critical Development Rules to concise table format (saved 49 lines)
- Consolidated redundant sections (saved 13 lines)
- Removed duplicate content and improved organization

### Tooling Added
- `scripts/check-claude-md-size.sh` - Monitors CLAUDE.md size with warnings at 240 lines and errors at 250 lines
- `scripts/pre-commit-claude-check.example` - Example pre-commit hook for automated size checking
- Pre-commit hook installed locally to prevent future size creep

## Test plan
- [x] Verified all extracted content is properly placed in documentation
- [x] Tested size checker script works correctly
- [x] Confirmed pre-commit hook runs and validates size
- [x] All essential information remains in CLAUDE.md with references to detailed docs
- [x] Build and tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)