### PR TITLE
fix(ci): remove duplicate BDD test runs

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -2,19 +2,6 @@ name: Asthra BDD Tests
 
 on:
   workflow_call:
-  push:
-    branches: [ main, develop ]
-    paths:
-      - 'bdd/**'
-      - 'src/**'
-      - '.github/workflows/bdd.yml'
-  pull_request:
-    branches: [ main, develop ]
-    paths:
-      - 'bdd/**'
-      - 'src/**'
-      - '.github/workflows/bdd.yml'
-  workflow_dispatch:
 
 env:
   ASTHRA_VERSION: "0.1.0"


### PR DESCRIPTION
## Summary

This PR fixes the issue where BDD tests were running twice in the CI pipeline, causing confusion with duplicate status check entries.

## Problem

The BDD workflow (`bdd.yml`) was configured with both:
- Direct triggers (`push`, `pull_request`, `workflow_dispatch`)
- `workflow_call` trigger for being called by other workflows

This caused BDD tests to run twice:
1. **Standalone**: "BDD Tests (linux)" and "BDD Tests (macos)" 
2. **Via CI Pipeline**: "BDD Tests / BDD Tests (linux)" and "BDD Tests / BDD Tests (macos)"

## Solution

Removed all direct triggers from `bdd.yml`, keeping only `workflow_call`. This ensures BDD tests run exclusively as part of the main CI pipeline.

## Benefits

- ✅ Eliminates duplicate BDD test runs
- ✅ Cleaner GitHub status checks (no more confusion)
- ✅ Better CI resource utilization (tests run once, not twice)
- ✅ BDD tests remain mandatory through CI pipeline dependencies

## Testing

After this change, you should only see BDD test entries as part of the main CI pipeline, not as standalone runs.