### PR TITLE
docs: update SECURITY.md to clarify pre-1.0 status

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-We provide security updates for the following versions of Asthra:
+Asthra has not yet reached version 1.0, so there are currently no officially supported versions. Once we reach version 1.0, we will provide security updates for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
@@ -43,7 +43,7 @@ We aim to respond to security reports according to the following timeline:
 - **Initial Response**: Within 48 hours
 - **Confirmation**: Within 7 days
 - **Fix Development**: Within 30 days for critical issues
-- **Public Disclosure**: After fix is released and users have time to update
+- **Public Disclosure**: After the fix is released and users have time to update
 
 ## Security Features
 
@@ -52,7 +52,7 @@ Asthra is designed with security as a core principle:
 ### Memory Safety
 - **Four-Zone Memory Model**: Automatic memory management with safety guarantees
 - **Bounds Checking**: All array and slice operations are bounds-checked
-- **Ownership Semantics**: Transfer semantics prevent use-after-free and double-free
+- **Ownership Semantics**: Transfer semantics prevent use-after-free and double-free errors
 - **Safe FFI**: Automatic C interoperability with memory safety
 
 ### Compilation Security


### PR DESCRIPTION
## Summary
- Clarify that Asthra hasn't reached version 1.0 yet in the supported versions section
- Fix minor grammar issues for better clarity

## Changes
- Updated supported versions section to indicate pre-1.0 status
- Added "the" before "fix is released" in the response timeline
- Added "errors" after "double-free" for grammatical correctness

## Test plan
Documentation-only change, no testing required.

🤖 Generated with [Claude Code](https://claude.ai/code)