### PR TITLE
feat(compiler): add --pie and --no-pie flags for explicit PIE control

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -37,6 +37,8 @@ void cli_print_usage(const char *program_name) {
     printf("  --emit-llvm             Deprecated - Use --emit llvm-ir\n");
     printf("  --emit-asm              Deprecated - Use --emit asm\n");
     printf("  --no-stdlib             Don't link standard library\n");
+    printf("  --pie                   Force generation of position-independent executables\n");
+    printf("  --no-pie                Disable PIE generation\n");
     printf("  -I, --include <path>    Add include path\n");
     printf("  -L, --library-path <path> Add library search path\n");
     printf("  -l, --library <name>    Link library\n");
@@ -232,6 +234,8 @@ int cli_parse_arguments(int argc, char *argv[], CliOptions *options) {
         {.name = "test-mode", .has_arg = no_argument, .flag = 0, .val = 1003},
         {.name = "version", .has_arg = no_argument, .flag = 0, .val = 1004},
         {.name = "coverage", .has_arg = no_argument, .flag = 0, .val = 1006},
+        {.name = "pie", .has_arg = no_argument, .flag = 0, .val = 1007},
+        {.name = "no-pie", .has_arg = no_argument, .flag = 0, .val = 1008},
         {.name = "help", .has_arg = no_argument, .flag = 0, .val = 'h'},
         {0, 0, 0, 0}};
 #endif
@@ -326,6 +330,12 @@ int cli_parse_arguments(int argc, char *argv[], CliOptions *options) {
             goto cleanup_and_exit;
         case 1006: // --coverage
             options->compiler_options.coverage = true;
+            break;
+        case 1007: // --pie
+            options->compiler_options.pie_mode = ASTHRA_PIE_FORCE_ENABLED;
+            break;
+        case 1008: // --no-pie
+            options->compiler_options.pie_mode = ASTHRA_PIE_FORCE_DISABLED;
             break;
         case 'h':
             options->show_help = true;

--- a/src/codegen/llvm_linking.c
+++ b/src/codegen/llvm_linking.c
@@ -96,6 +96,16 @@ AsthraLLVMToolResult asthra_llvm_link(const char **object_files, size_t num_obje
         argv[argc++] = "-fcoverage-mapping";
     }
 
+    // Add PIE flags based on the mode
+    if (options->pie_mode == ASTHRA_PIE_FORCE_ENABLED) {
+        argv[argc++] = "-pie";
+        argv[argc++] = "-fPIE";
+    } else if (options->pie_mode == ASTHRA_PIE_FORCE_DISABLED) {
+        argv[argc++] = "-no-pie";
+        argv[argc++] = "-fno-PIE";
+    }
+    // For ASTHRA_PIE_DEFAULT, let the system use its default behavior
+
     argv[argc] = NULL;
 
     AsthraLLVMToolResult result = execute_command(argv, options->verbose);

--- a/src/codegen/llvm_pipeline.c
+++ b/src/codegen/llvm_pipeline.c
@@ -138,6 +138,15 @@ AsthraLLVMToolResult asthra_llvm_compile_pipeline(const char *ir_file, const cha
                 argv[argc++] = "-g";
             }
 
+            // Add PIE flags based on the mode
+            if (options->pie_mode == ASTHRA_PIE_FORCE_ENABLED) {
+                argv[argc++] = "-pie";
+                argv[argc++] = "-fPIE";
+            } else if (options->pie_mode == ASTHRA_PIE_FORCE_DISABLED) {
+                argv[argc++] = "-no-pie";
+                argv[argc++] = "-fno-PIE";
+            }
+
             argv[argc] = NULL;
 
             // Debug: print the command being executed
@@ -172,7 +181,8 @@ AsthraLLVMToolResult asthra_llvm_compile_pipeline(const char *ir_file, const cha
                                                       .target_triple =
                                                           compile_options.target_triple,
                                                       .verbose = options->verbose,
-                                                      .coverage = options->coverage};
+                                                      .coverage = options->coverage,
+                                                      .pie_mode = options->pie_mode};
 
                 asthra_llvm_tool_result_free(&result);
                 result = asthra_llvm_link(objects, 1, &link_options);

--- a/src/codegen/llvm_tools.h
+++ b/src/codegen/llvm_tools.h
@@ -41,6 +41,7 @@ typedef struct {
     bool debug_info;
     bool verbose;
     bool coverage; // Enable coverage instrumentation
+    AsthraPIEMode pie_mode; // Position Independent Executable mode
 
     // Tool-specific options
     bool use_integrated_as;    // Use clang integrated assembler

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -79,6 +79,13 @@ typedef enum {
     ASTHRA_FORMAT_EXECUTABLE // executable (via clang)
 } AsthraOutputFormat;
 
+// Position Independent Executable (PIE) mode
+typedef enum {
+    ASTHRA_PIE_DEFAULT,      // Use platform-specific defaults
+    ASTHRA_PIE_FORCE_ENABLED,  // Explicitly enable PIE
+    ASTHRA_PIE_FORCE_DISABLED  // Explicitly disable PIE
+} AsthraPIEMode;
+
 // Assembly syntax styles (deprecated - kept for API compatibility)
 typedef enum {
     ASTHRA_ASM_SYNTAX_ATT,  // AT&T syntax (no longer used)
@@ -111,6 +118,7 @@ struct AsthraCompilerOptions {
     bool emit_asm;  // Deprecated - use output_format instead
     bool no_stdlib;
     bool coverage; // Enable coverage instrumentation
+    AsthraPIEMode pie_mode; // Position Independent Executable mode
 
     // Dynamic path and library management using flexible arrays
     struct AsthraArgumentList *include_paths;

--- a/src/compiler/options_validation.c
+++ b/src/compiler/options_validation.c
@@ -30,6 +30,8 @@ AsthraCompilerOptions asthra_compiler_default_options(void) {
                                    .emit_llvm = false,
                                    .emit_asm = false,
                                    .no_stdlib = false,
+                                   .coverage = false,
+                                   .pie_mode = ASTHRA_PIE_DEFAULT,
                                    .include_paths = NULL,
                                    .library_paths = NULL,
                                    .libraries = NULL};
@@ -50,6 +52,8 @@ AsthraCompilerOptions asthra_compiler_options_create(const char *input_file,
                                    .emit_llvm = false,
                                    .emit_asm = false,
                                    .no_stdlib = false,
+                                   .coverage = false,
+                                   .pie_mode = ASTHRA_PIE_DEFAULT,
                                    .include_paths = asthra_argument_list_create(8),
                                    .library_paths = asthra_argument_list_create(8),
                                    .libraries = asthra_argument_list_create(8)};

--- a/tests/compiler/CMakeLists.txt
+++ b/tests/compiler/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Compiler Tests CMakeLists.txt
+# Tests for compiler command-line interface and options
+
+# PIE flag tests
+add_asthra_test(compiler test_pie_flags.c)

--- a/tests/compiler/test_pie_flags.c
+++ b/tests/compiler/test_pie_flags.c
@@ -1,0 +1,188 @@
+/**
+ * Tests for PIE (Position Independent Executable) flags
+ * Tests the --pie and --no-pie command-line options
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../../src/compiler.h"
+#include "../../src/cli.h"
+
+// Test that pie_mode defaults to ASTHRA_PIE_DEFAULT
+static bool test_pie_default(void) {
+    printf("Testing PIE default mode...\n");
+    
+    AsthraCompilerOptions options = asthra_compiler_default_options();
+    
+    if (options.pie_mode != ASTHRA_PIE_DEFAULT) {
+        printf("FAIL: PIE mode should default to ASTHRA_PIE_DEFAULT\n");
+        return false;
+    }
+    
+    printf("PASS: PIE defaults to platform-specific behavior\n");
+    return true;
+}
+
+// Test parsing --pie flag
+static bool test_pie_enabled_flag(void) {
+    printf("Testing --pie flag parsing...\n");
+    
+    // Reset getopt state
+    extern int optind;
+    optind = 1;
+    
+    // Simulate command line: asthra --pie test.asthra
+    char *argv[] = {"asthra", "--pie", "test.asthra"};
+    int argc = 3;
+    
+    CliOptions cli_options = cli_options_init();
+    int result = cli_parse_arguments(argc, argv, &cli_options);
+    
+    if (result != 0) {
+        printf("FAIL: Failed to parse --pie flag\n");
+        return false;
+    }
+    
+    if (cli_options.compiler_options.pie_mode != ASTHRA_PIE_FORCE_ENABLED) {
+        printf("FAIL: --pie flag should set PIE mode to ASTHRA_PIE_FORCE_ENABLED\n");
+        cli_options_cleanup(&cli_options);
+        return false;
+    }
+    
+    cli_options_cleanup(&cli_options);
+    printf("PASS: --pie flag correctly enables PIE\n");
+    return true;
+}
+
+// Test parsing --no-pie flag
+static bool test_pie_disabled_flag(void) {
+    printf("Testing --no-pie flag parsing...\n");
+    
+    // Reset getopt state
+    extern int optind;
+    optind = 1;
+    
+    // Simulate command line: asthra --no-pie test.asthra
+    char *argv[] = {"asthra", "--no-pie", "test.asthra"};
+    int argc = 3;
+    
+    CliOptions cli_options = cli_options_init();
+    int result = cli_parse_arguments(argc, argv, &cli_options);
+    
+    if (result != 0) {
+        printf("FAIL: Failed to parse --no-pie flag (result=%d)\n", result);
+        return false;
+    }
+    
+    printf("DEBUG: PIE mode after parsing: %d (expected %d)\n", 
+           cli_options.compiler_options.pie_mode, ASTHRA_PIE_FORCE_DISABLED);
+    
+    if (cli_options.compiler_options.pie_mode != ASTHRA_PIE_FORCE_DISABLED) {
+        printf("FAIL: --no-pie flag should set PIE mode to ASTHRA_PIE_FORCE_DISABLED\n");
+        cli_options_cleanup(&cli_options);
+        return false;
+    }
+    
+    cli_options_cleanup(&cli_options);
+    printf("PASS: --no-pie flag correctly disables PIE\n");
+    return true;
+}
+
+// Test that --pie and --no-pie are mutually exclusive
+static bool test_pie_mutual_exclusion(void) {
+    printf("Testing PIE flag mutual exclusion...\n");
+    
+    // Reset getopt state
+    extern int optind;
+    optind = 1;
+    
+    // First set --pie, then --no-pie should override
+    char *argv[] = {"asthra", "--pie", "--no-pie", "test.asthra"};
+    int argc = 4;
+    
+    CliOptions cli_options = cli_options_init();
+    int result = cli_parse_arguments(argc, argv, &cli_options);
+    
+    if (result != 0) {
+        printf("FAIL: Failed to parse PIE flags\n");
+        return false;
+    }
+    
+    // The last flag should win
+    if (cli_options.compiler_options.pie_mode != ASTHRA_PIE_FORCE_DISABLED) {
+        printf("FAIL: Last PIE flag should take precedence\n");
+        cli_options_cleanup(&cli_options);
+        return false;
+    }
+    
+    cli_options_cleanup(&cli_options);
+    printf("PASS: PIE flags are mutually exclusive (last wins)\n");
+    return true;
+}
+
+// Test PIE mode with other flags
+static bool test_pie_with_other_flags(void) {
+    printf("Testing PIE with other compiler flags...\n");
+    
+    // Reset getopt state
+    extern int optind;
+    optind = 1;
+    
+    // Combine PIE with optimization and debug flags
+    char *argv[] = {"asthra", "-O3", "--pie", "-g", "test.asthra"};
+    int argc = 5;
+    
+    CliOptions cli_options = cli_options_init();
+    int result = cli_parse_arguments(argc, argv, &cli_options);
+    
+    if (result != 0) {
+        printf("FAIL: Failed to parse combined flags\n");
+        return false;
+    }
+    
+    if (cli_options.compiler_options.pie_mode != ASTHRA_PIE_FORCE_ENABLED) {
+        printf("FAIL: PIE mode not set correctly with other flags\n");
+        cli_options_cleanup(&cli_options);
+        return false;
+    }
+    
+    if (cli_options.compiler_options.opt_level != ASTHRA_OPT_AGGRESSIVE) {
+        printf("FAIL: Optimization level not preserved\n");
+        cli_options_cleanup(&cli_options);
+        return false;
+    }
+    
+    if (!cli_options.compiler_options.debug_info) {
+        printf("FAIL: Debug info flag not preserved\n");
+        cli_options_cleanup(&cli_options);
+        return false;
+    }
+    
+    cli_options_cleanup(&cli_options);
+    printf("PASS: PIE works correctly with other flags\n");
+    return true;
+}
+
+int main(void) {
+    printf("=== PIE Flag Tests ===\n\n");
+    
+    int tests_passed = 0;
+    int tests_failed = 0;
+    
+    // Run tests
+    if (test_pie_default()) tests_passed++; else tests_failed++;
+    if (test_pie_enabled_flag()) tests_passed++; else tests_failed++;
+    if (test_pie_disabled_flag()) tests_passed++; else tests_failed++;
+    if (test_pie_mutual_exclusion()) tests_passed++; else tests_failed++;
+    if (test_pie_with_other_flags()) tests_passed++; else tests_failed++;
+    
+    printf("\n=== Test Summary ===\n");
+    printf("Tests passed: %d\n", tests_passed);
+    printf("Tests failed: %d\n", tests_failed);
+    printf("Total tests: %d\n", tests_passed + tests_failed);
+    
+    return tests_failed > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
This PR implements explicit Position Independent Executable (PIE) control for the Asthra compiler as requested in issue #116. This ensures predictable linking behavior across different linkers and platforms.

## Changes
- Added `AsthraPIEMode` enum with `DEFAULT`, `FORCE_ENABLED`, and `FORCE_DISABLED` options
- Added `pie_mode` field to `AsthraCompilerOptions` and `AsthraLLVMToolOptions` structures
- Updated CLI to support `--pie` and `--no-pie` command-line flags
- Modified linking implementation to pass appropriate PIE flags (`-pie`/`-fPIE` or `-no-pie`/`-fno-PIE`) to clang
- Added comprehensive unit tests for PIE flag functionality

## Default Behavior
The default behavior is `ASTHRA_PIE_DEFAULT` which allows the system linker to use its platform-specific defaults. This ensures the compiler doesn't make assumptions about PIE requirements while still allowing explicit control when needed.

## Test Results
All tests pass successfully:
- ✅ Core compilation pipeline: PASSED
- ✅ Cross-cutting components: PASSED  
- ✅ Supporting infrastructure: PASSED
- ✅ BDD tests: 95% passed (pre-existing @wip test failures unrelated to this change)

## Usage
```bash
# Force PIE generation
asthra --pie source.asthra

# Disable PIE generation  
asthra --no-pie source.asthra

# Use system defaults
asthra source.asthra
```

Closes #116

🤖 Generated with [Claude Code](https://claude.ai/code)