### PR TITLE
fix(codegen): complete PIE implementation for object compilation

### DIFF
--- a/src/codegen/llvm_compilation.c
+++ b/src/codegen/llvm_compilation.c
@@ -64,6 +64,16 @@ AsthraLLVMToolResult asthra_llvm_compile(const char *input_file,
         argv[argc++] = options->features;
     }
 
+    // Add relocation model based on PIE mode
+    if (options->pie_mode == ASTHRA_PIE_FORCE_ENABLED ||
+        (options->pie_mode == ASTHRA_PIE_DEFAULT &&
+         options->output_format == ASTHRA_FORMAT_OBJECT)) {
+        argv[argc++] = "-relocation-model=pic";
+    } else if (options->pie_mode == ASTHRA_PIE_FORCE_DISABLED) {
+        argv[argc++] = "-relocation-model=static";
+    }
+    // For ASTHRA_PIE_DEFAULT with non-object output, let llc use its default
+
     argv[argc] = NULL;
 
     return execute_command(argv, options->verbose);

--- a/src/codegen/llvm_pipeline.c
+++ b/src/codegen/llvm_pipeline.c
@@ -170,7 +170,8 @@ AsthraLLVMToolResult asthra_llvm_compile_pipeline(const char *ir_file, const cha
                 .target_triple = asthra_llvm_target_triple(options->target_arch),
                 .debug_info = options->debug_info,
                 .verbose = options->verbose,
-                .coverage = options->coverage};
+                .coverage = options->coverage,
+                .pie_mode = options->pie_mode};
 
             result = asthra_llvm_compile(compile_input, &compile_options);
             if (result.success) {


### PR DESCRIPTION
## Summary
This PR completes the PIE (Position Independent Executable) implementation started in #117 by adding proper relocation model support during the LLVM object compilation phase.

## Problem
After PR #117 was merged, Linux CI was still failing with PIE-related linking errors:
```
/usr/bin/ld: bdd-temp/simple_enum.tmp.o: relocation R_X86_64_32 against `.rodata.str1.1' can not be used when making a PIE object; recompile with -fPIE
```

The issue was that while #117 added PIE flags to the linking phase, it didn't handle the object compilation phase where `llc` generates object files.

## Solution
This PR adds:
1. **Relocation model support in `llvm_compilation.c`**:
   - `-relocation-model=pic` for PIE-enabled builds
   - `-relocation-model=static` for PIE-disabled builds
   - Respects platform defaults for `ASTHRA_PIE_DEFAULT`

2. **PIE mode propagation in `llvm_pipeline.c`**:
   - Passes `pie_mode` from pipeline options to compile options
   - Ensures consistency between compilation and linking phases

## Testing
- ✅ Existing PIE flag tests continue to pass
- ✅ The fix ensures object files are compiled with the correct relocation model
- ✅ This should resolve the Linux CI failures

## Related Issues
- Completes implementation from #117
- Fixes remaining CI failures from #116

🤖 Generated with [Claude Code](https://claude.ai/code)