### PR TITLE
test(bdd): remove @wip tags from binary and hex literal scenarios

### DIFF
--- a/bdd/features/bitwise_operators.feature
+++ b/bdd/features/bitwise_operators.feature
@@ -355,7 +355,6 @@ Feature: Bitwise Operators
     Then the compilation should fail
     And the error message should contain "shift"
 
-  @wip
   Scenario: Binary literals with bitwise operations
     Given I have a file "binary_literals.asthra" with:
       """

--- a/bdd/features/primitive_types.feature
+++ b/bdd/features/primitive_types.feature
@@ -255,7 +255,6 @@ Feature: Primitive Types
     Then the output should contain "Binary literals work"
     And the exit code should be 0
 
-  @wip
   Scenario: Hexadecimal literals
     Given I have a file "hex_literals.asthra" with:
       """


### PR DESCRIPTION
## Summary
- Remove @wip tags from binary literals with bitwise operations scenario
- Remove @wip tags from hexadecimal literals scenario
- These scenarios are now ready for implementation and testing

## Test plan
- [ ] Verify BDD tests can detect these scenarios
- [ ] Confirm no regression in existing tests
- [ ] Check that implementation can proceed for these features

🤖 Generated with [Claude Code](https://claude.ai/code)