### PR TITLE
feat(imports): implement duplicate import detection

### DIFF
--- a/bdd/features/import_system.feature
+++ b/bdd/features/import_system.feature
@@ -160,7 +160,6 @@ Feature: Import System
     Then the compilation should fail
     And the error message should contain "invalid import path"
 
-  @wip
   Scenario: Duplicate imports
     Given I have a file "duplicate_imports.asthra" with:
       """

--- a/bdd/steps/unit/import_system_steps.c
+++ b/bdd/steps/unit/import_system_steps.c
@@ -206,7 +206,7 @@ BddTestCase import_system_test_cases[] = {
     BDD_TEST_CASE(import_without_semicolon, test_import_without_semicolon),
     BDD_TEST_CASE(import_before_package, test_import_before_package),
     BDD_WIP_TEST_CASE(import_invalid_path, test_import_invalid_path),
-    BDD_WIP_TEST_CASE(duplicate_imports, test_duplicate_imports),
+    BDD_TEST_CASE(duplicate_imports, test_duplicate_imports),
     BDD_WIP_TEST_CASE(conflicting_aliases, test_conflicting_aliases),
 };
 

--- a/src/analysis/semantic_analyzer_core.h
+++ b/src/analysis/semantic_analyzer_core.h
@@ -34,6 +34,11 @@ _Static_assert(__STDC_VERSION__ >= 201710L,
 // SEMANTIC ANALYZER STRUCTURE
 // =============================================================================
 
+typedef struct ImportedModule {
+    char *path;
+    SourceLocation location;  // Location of the import declaration
+} ImportedModule;
+
 typedef struct SemanticAnalyzer {
     SymbolTable *global_scope;
     SymbolTable *current_scope;
@@ -43,6 +48,11 @@ typedef struct SemanticAnalyzer {
     // Predeclared identifiers (log, range, etc.)
     PredeclaredIdentifier *predeclared_identifiers;
     size_t predeclared_count;
+
+    // Import tracking
+    ImportedModule *imported_modules;
+    size_t imported_count;
+    size_t imported_capacity;
 
     // Error handling
     SemanticError *errors;

--- a/src/analysis/semantic_imports.c
+++ b/src/analysis/semantic_imports.c
@@ -26,6 +26,37 @@ bool analyze_import_declaration(SemanticAnalyzer *analyzer, ASTNode *import_decl
     const char *path = import_decl->data.import_decl.path;
     const char *alias = import_decl->data.import_decl.alias;
 
+    // Check for duplicate imports
+    for (size_t i = 0; i < analyzer->imported_count; i++) {
+        if (strcmp(analyzer->imported_modules[i].path, path) == 0) {
+            semantic_report_error(analyzer, SEMANTIC_ERROR_DUPLICATE_SYMBOL, import_decl->location,
+                                  "Duplicate import: Module '%s' has already been imported at line %d, column %d", 
+                                  path, 
+                                  analyzer->imported_modules[i].location.line,
+                                  analyzer->imported_modules[i].location.column);
+            return false;
+        }
+    }
+
+    // Add import to tracking list
+    if (analyzer->imported_count >= analyzer->imported_capacity) {
+        size_t new_capacity = analyzer->imported_capacity == 0 ? 16 : analyzer->imported_capacity * 2;
+        ImportedModule *new_modules = realloc(analyzer->imported_modules, 
+                                              new_capacity * sizeof(ImportedModule));
+        if (!new_modules) {
+            semantic_report_error(analyzer, SEMANTIC_ERROR_NONE, import_decl->location,
+                                  "Failed to allocate memory for import tracking");
+            return false;
+        }
+        analyzer->imported_modules = new_modules;
+        analyzer->imported_capacity = new_capacity;
+    }
+
+    // Store the import
+    analyzer->imported_modules[analyzer->imported_count].path = strdup(path);
+    analyzer->imported_modules[analyzer->imported_count].location = import_decl->location;
+    analyzer->imported_count++;
+
     if (alias) {
         // TODO: In a real implementation, we would load the module
         // and get its symbol table. For now, we'll create a placeholder.

--- a/src/analysis/semantic_lifecycle.c
+++ b/src/analysis/semantic_lifecycle.c
@@ -35,6 +35,9 @@ SemanticAnalyzer *semantic_analyzer_create(void) {
                                    .current_scope = NULL,
                                    .builtin_types = NULL,
                                    .builtin_type_count = 0,
+                                   .imported_modules = NULL,
+                                   .imported_count = 0,
+                                   .imported_capacity = 0,
                                    .errors = NULL,
                                    .last_error = NULL,
                                    .error_count = 0,
@@ -92,6 +95,12 @@ void semantic_analyzer_destroy(SemanticAnalyzer *analyzer) {
     // Free predeclared identifiers
     free(analyzer->predeclared_identifiers);
 
+    // Free imported modules
+    for (size_t i = 0; i < analyzer->imported_count; i++) {
+        free(analyzer->imported_modules[i].path);
+    }
+    free(analyzer->imported_modules);
+
     free(analyzer);
 }
 
@@ -113,6 +122,15 @@ void semantic_analyzer_reset(SemanticAnalyzer *analyzer) {
 
     // Reset loop depth
     analyzer->loop_depth = 0;
+
+    // Clear imported modules
+    for (size_t i = 0; i < analyzer->imported_count; i++) {
+        free(analyzer->imported_modules[i].path);
+    }
+    free(analyzer->imported_modules);
+    analyzer->imported_modules = NULL;
+    analyzer->imported_count = 0;
+    analyzer->imported_capacity = 0;
 }
 
 void semantic_analyzer_set_test_mode(SemanticAnalyzer *analyzer, bool enable) {


### PR DESCRIPTION
## Summary
- Implements duplicate import detection as identified in BDD @wip scenario
- Adds clear error messages showing location of original import
- Treats duplicate imports as compilation errors

## Implementation Details
- Added `ImportedModule` tracking structure to `SemanticAnalyzer`
- Track all imported modules with their source locations during semantic analysis
- Check for duplicates when processing each import declaration
- Report error with location of both original and duplicate import

## Testing
- All existing tests pass
- BDD test for duplicate imports now passing (removed @wip tag)
- Error message format: `Duplicate import: Module 'stdlib/io' has already been imported at line X, column Y`

Closes #128

🤖 Generated with [Claude Code](https://claude.ai/code)