### PR TITLE
fix: remove deprecated --emit-llvm and --emit-asm CLI options

### DIFF
--- a/docs/contributor/guides/llvm-backend-implementation.md
+++ b/docs/contributor/guides/llvm-backend-implementation.md
@@ -79,11 +79,11 @@ The build system will automatically find LLVM using:
 
 ### 5. Using the LLVM Backend
 
-Once built with LLVM support, use the `--emit-llvm` flag:
+Once built with LLVM support, use the `--emit` flag with the desired format:
 
 ```bash
-asthra --emit-llvm input.as    # Generates input.ll (text IR)
-asthra --emit-llvm input.as -o output.bc  # Generates bitcode
+asthra --emit llvm-ir input.as    # Generates input.ll (text IR)
+asthra --emit llvm-bc input.as -o output.bc  # Generates bitcode
 ```
 
 ## Architecture Decisions

--- a/docs/user-manual/compiler-reference.md
+++ b/docs/user-manual/compiler-reference.md
@@ -150,15 +150,6 @@ Display compiler version information and exit.
 **`-h, --help`**  
 Show help message with all available options.
 
-### Deprecated Options
-
-These options are maintained for backward compatibility but should not be used in new code:
-
-**`--emit-llvm`**  
-Deprecated. Use `--emit llvm-ir` instead.
-
-**`--emit-asm`**  
-Deprecated. Use `--emit asm` instead.
 
 ## Examples
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -35,8 +35,6 @@ void cli_print_usage(const char *program_name) {
            "native)\n");
     printf("  -b, --backend <type>    Backend type (llvm only, default: llvm)\n");
     printf("  --emit <format>         Output format: llvm-ir, llvm-bc, asm, obj, exe\n");
-    printf("  --emit-llvm             Deprecated - Use --emit llvm-ir\n");
-    printf("  --emit-asm              Deprecated - Use --emit asm\n");
     printf("  --no-stdlib             Don't link standard library\n");
     printf("  --pie                   Force generation of position-independent executables\n");
     printf("  --no-pie                Disable PIE generation\n");
@@ -203,8 +201,6 @@ int cli_parse_arguments(int argc, char *argv[], CliOptions *options) {
         {.name = "verbose", .has_arg = no_argument, .flag = 0, .val = 'v'},
         {.name = "target", .has_arg = required_argument, .flag = 0, .val = 't'},
         {.name = "backend", .has_arg = required_argument, .flag = 0, .val = 'b'},
-        {.name = "emit-llvm", .has_arg = no_argument, .flag = 0, .val = 1000},
-        {.name = "emit-asm", .has_arg = no_argument, .flag = 0, .val = 1001},
         {.name = "emit", .has_arg = required_argument, .flag = 0, .val = 1005},
         {.name = "no-stdlib", .has_arg = no_argument, .flag = 0, .val = 1002},
         {.name = "include", .has_arg = required_argument, .flag = 0, .val = 'I'},
@@ -270,16 +266,6 @@ int cli_parse_arguments(int argc, char *argv[], CliOptions *options) {
                 fprintf(stderr, "Error: Failed to add library\n");
                 goto cleanup_and_exit;
             }
-            break;
-        case 1000: // --emit-llvm
-            options->compiler_options.emit_llvm = true;
-            fprintf(stderr,
-                    "Warning: --emit-llvm is deprecated. LLVM IR is now the default backend.\n");
-            break;
-        case 1001: // --emit-asm
-            options->compiler_options.emit_asm = true;
-            fprintf(stderr,
-                    "Warning: --emit-asm is deprecated. Assembly backend has been removed.\n");
             break;
         case 1002: // --no-stdlib
             options->compiler_options.no_stdlib = true;
@@ -350,15 +336,6 @@ int cli_parse_arguments(int argc, char *argv[], CliOptions *options) {
     options->compiler_options.libraries = libraries;
 
     // Backend type is always LLVM now
-    // Warn if legacy flags are used
-    if (options->compiler_options.emit_llvm) {
-        fprintf(stderr,
-                "Warning: --emit-llvm flag is deprecated. LLVM IR is now the default backend.\n");
-    }
-    if (options->compiler_options.emit_asm) {
-        fprintf(stderr,
-                "Warning: --emit-asm flag is deprecated. Assembly backend has been removed.\n");
-    }
 
     return 0;
 

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -108,8 +108,6 @@ struct AsthraCompilerOptions {
     AsthraAssemblySyntax asm_syntax;  // Deprecated - kept for API compatibility
     bool debug_info;
     bool verbose;
-    bool emit_llvm; // Deprecated - LLVM is now always used
-    bool emit_asm;  // Deprecated - use output_format instead
     bool no_stdlib;
     bool coverage;          // Enable coverage instrumentation
     AsthraPIEMode pie_mode; // Position Independent Executable mode

--- a/src/compiler/options_validation.c
+++ b/src/compiler/options_validation.c
@@ -26,8 +26,6 @@ AsthraCompilerOptions asthra_compiler_default_options(void) {
                                    .asm_syntax = ASTHRA_ASM_SYNTAX_ATT,
                                    .debug_info = false,
                                    .verbose = false,
-                                   .emit_llvm = false,
-                                   .emit_asm = false,
                                    .no_stdlib = false,
                                    .coverage = false,
                                    .pie_mode = ASTHRA_PIE_DEFAULT,
@@ -47,8 +45,6 @@ AsthraCompilerOptions asthra_compiler_options_create(const char *input_file,
                                    .asm_syntax = ASTHRA_ASM_SYNTAX_ATT,
                                    .debug_info = false,
                                    .verbose = false,
-                                   .emit_llvm = false,
-                                   .emit_asm = false,
                                    .no_stdlib = false,
                                    .coverage = false,
                                    .pie_mode = ASTHRA_PIE_DEFAULT,
@@ -85,11 +81,6 @@ bool asthra_compiler_validate_options(const AsthraCompilerOptions *options) {
         return false;
     }
 #endif
-
-    // Validate mutually exclusive options
-    if (options->emit_llvm && options->emit_asm) {
-        return false; // Can't emit both LLVM IR and assembly
-    }
 
     return true;
 }

--- a/tests/basic/test_basic.c
+++ b/tests/basic/test_basic.c
@@ -65,8 +65,6 @@ static bool test_compiler_context_lifecycle(void) {
                                      .target_arch = ASTHRA_TARGET_X86_64,
                                      .debug_info = false,
                                      .verbose = false,
-                                     .emit_llvm = false,
-                                     .emit_asm = false,
                                      .no_stdlib = false,
                                      .include_paths = NULL,
                                      .library_paths = NULL,

--- a/tests/basic/test_basic_compiler_integration.c
+++ b/tests/basic/test_basic_compiler_integration.c
@@ -342,8 +342,6 @@ bool test_interface_validation(void) {
                                      .target_arch = ASTHRA_TARGET_X86_64,
                                      .debug_info = false,
                                      .verbose = false,
-                                     .emit_llvm = false,
-                                     .emit_asm = false,
                                      .no_stdlib = false,
                                      .include_paths = NULL,
                                      .library_paths = NULL,


### PR DESCRIPTION
## Summary
- Removes deprecated `--emit-llvm` and `--emit-asm` command line options
- Removes corresponding fields from `AsthraCompilerOptions` struct
- Updates documentation to reflect these changes

## Changes
- **CLI Parser**: Removed `--emit-llvm` and `--emit-asm` option handling from `src/cli.c`
- **Compiler Options**: Removed `emit_llvm` and `emit_asm` fields from `AsthraCompilerOptions` struct in `src/compiler.h`
- **Validation**: Removed validation logic for these deprecated fields from `src/compiler/options_validation.c`
- **Documentation**: Updated `llvm-backend-implementation.md` to use new `--emit` syntax and removed deprecated options section from `compiler-reference.md`
- **Tests**: Fixed test files that were initializing the removed fields

## Test Plan
- [x] Build passes successfully
- [x] All semantic tests pass
- [x] Code formatted with clang-format
- [x] No test files use deprecated options

Closes #144

🤖 Generated with [Claude Code](https://claude.ai/code)