### PR TITLE
Remove ARM 32-bit and x86 32-bit architecture support

### DIFF
--- a/.github/workflows/on-demand-test.yml
+++ b/.github/workflows/on-demand-test.yml
@@ -68,7 +68,6 @@ on:
           - 'native'
           - 'x86_64'
           - 'aarch64'
-          - 'arm'
           - 'both-x86-arm'
 
 env:

--- a/cmake/Platform.cmake
+++ b/cmake/Platform.cmake
@@ -12,18 +12,10 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64|amd64|AMD64)")
     set(ASTHRA_ARCH "x86_64")
     set(ASTHRA_ARCH_X64 TRUE)
     set(ASTHRA_POINTER_SIZE 8)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(i[3-6]86|x86)")
-    set(ASTHRA_ARCH "x86")
-    set(ASTHRA_ARCH_X86 TRUE)
-    set(ASTHRA_POINTER_SIZE 4)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "(arm64|aarch64)")
     set(ASTHRA_ARCH "arm64")
     set(ASTHRA_ARCH_ARM64 TRUE)
     set(ASTHRA_POINTER_SIZE 8)
-elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-    set(ASTHRA_ARCH "arm")
-    set(ASTHRA_ARCH_ARM TRUE)
-    set(ASTHRA_POINTER_SIZE 4)
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
     set(ASTHRA_ARCH "riscv64")
     set(ASTHRA_ARCH_RISCV64 TRUE)
@@ -205,7 +197,7 @@ set(ASTHRA_HAS_TLS TRUE)
 set(ASTHRA_HAS_SIMD FALSE)
 
 # Check for SIMD support
-if(ASTHRA_ARCH_X64 OR ASTHRA_ARCH_X86)
+if(ASTHRA_ARCH_X64)
     include(CheckCSourceRuns)
     check_c_source_runs("
         #include <immintrin.h>
@@ -220,7 +212,7 @@ if(ASTHRA_ARCH_X64 OR ASTHRA_ARCH_X86)
         set(ASTHRA_HAS_SIMD TRUE)
         add_compile_definitions(ASTHRA_HAS_SSE=1)
     endif()
-elseif(ASTHRA_ARCH_ARM64 OR ASTHRA_ARCH_ARM)
+elseif(ASTHRA_ARCH_ARM64)
     check_c_source_compiles("
         #include <arm_neon.h>
         int main() {

--- a/docs/contributor/reference/platform-support.md
+++ b/docs/contributor/reference/platform-support.md
@@ -120,9 +120,6 @@ The Asthra compiler uses platform detection macros defined in `src/platform.h` t
 #if defined(__x86_64__) || defined(_M_X64)
     #define ASTHRA_ARCH_X64 1
     #define ASTHRA_ARCH_NAME "x64"
-#elif defined(__i386__) || defined(_M_IX86)
-    #define ASTHRA_ARCH_X86 1
-    #define ASTHRA_ARCH_NAME "x86"
 #elif defined(__aarch64__) || defined(_M_ARM64)
     #define ASTHRA_ARCH_ARM64 1
     #define ASTHRA_ARCH_NAME "arm64"

--- a/tests/security/test_security_helpers.c
+++ b/tests/security/test_security_helpers.c
@@ -107,7 +107,7 @@ void mock_csprng_fill(uint8_t *buffer, size_t size) {
 
 // RDTSC timing function (x86-64 specific)
 uint64_t rdtsc(void) {
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__)
     uint32_t lo, hi;
     __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
     return ((uint64_t)hi << 32) | lo;


### PR DESCRIPTION
## Summary
- Remove ARM 32-bit and x86 32-bit architecture detection from build system
- Update documentation and tests to reflect 64-bit only support
- Simplify platform detection logic in CMake

## Background
As discussed in #150, 32-bit architecture support is being deprecated across the industry:
- ARM Cortex-A cores dropped 32-bit support starting in 2022
- Operating systems like Kali Linux 2024.4 and Ubuntu 20.04+ dropped 32-bit support
- Hardware manufacturers are moving to 64-bit only designs
- Limited developer interest in using modern systems languages on legacy 32-bit systems

## Changes Made
1. **cmake/Platform.cmake**:
   - Removed x86 32-bit architecture detection (i386/i686)
   - Removed ARM 32-bit architecture detection
   - Updated SIMD detection logic to only check 64-bit architectures

2. **Documentation**:
   - Updated platform-support.md to remove 32-bit architecture examples

3. **CI/CD**:
   - Removed 'arm' option from on-demand test workflow

4. **Tests**:
   - Updated RDTSC timing function to only support x86_64
   - Fixed string concatenation issue in test_safe_ffi_annotation_context.c

## Supported Architectures After Change
- **ARM64/AArch64**: Primary architecture (macOS + Linux)
- **x86_64**: Linux only, production ready
- **RISC-V 64-bit**: Linux, emerging architecture

## Testing
All tests pass successfully after these changes.

Fixes #150

🤖 Generated with [Claude Code](https://claude.ai/code)